### PR TITLE
Fix example comment for root path

### DIFF
--- a/src/lib/utils/galleryPathUtils.ts
+++ b/src/lib/utils/galleryPathUtils.ts
@@ -115,7 +115,7 @@ export function sanitizeDayAlbumName(albumName: string): string {
  * Return the specified path's parent path and leaf item
  *  - /2001/12-31/image.jpg returns  '/2001/12-31/' and 'image.jpg'
  *  - /2001/12-31 returns '/2001/' and '12-31'
- *  - /2001 returns '/' and 2000'
+ *  - /2001 returns '/' and '2001'
  *  - / returns  '' and undefined
  *
  *  @param {String} path a path of the format /2001/12-31/image.jpg, or a subset thereof


### PR DESCRIPTION
## Summary
- fix incorrect example comment in `getParentAndNameFromPath`

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7f89656c832a855e62cd6dd820c4