### PR TITLE
Fix typo in models README

### DIFF
--- a/src/lib/models/README.md
+++ b/src/lib/models/README.md
@@ -1,6 +1,6 @@
 # Models
 
-This directory contains TypeScript classes repesenting the models of the things users interact with: Albums, Images, Thumbnails, etc
+This directory contains TypeScript classes representing the models of the things users interact with: Albums, Images, Thumbnails, etc
 
 ## These are pure data structures
 


### PR DESCRIPTION
## Summary
- fix 'repesenting' typo in models README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7f6fa928832a926bae7e1971fd4e