### PR TITLE
Fix rename error status

### DIFF
--- a/src/lib/stores/admin/AlbumRenameMachine.svelte.ts
+++ b/src/lib/stores/admin/AlbumRenameMachine.svelte.ts
@@ -62,7 +62,7 @@ class AlbumRenameMachine {
         // TODO: use immer to set state immutably
         const albumEntry = albumState.albums.get(oldAlbumPath);
         if (!albumEntry) throw new Error(`No album at path [${oldAlbumPath}]`);
-        albumEntry.status = AlbumStatus.DELETE_ERRORED;
+        albumEntry.status = AlbumStatus.RENAME_ERRORED;
         albumEntry.errorMessage = errorMessage;
         albumState.albums.set(oldAlbumPath, albumEntry);
 


### PR DESCRIPTION
## Summary
- correct rename machine to use RENAME_ERRORED status

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7f7d2360832a8d08afeb100a0697