### PR TITLE
Fix E2E tests on localhost by enabling preview server proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,8 @@ Requires Node.js >=24.0.0 (enforced).
 
 ## Tech Stack
 
-- **SvelteKit 2** with Svelte 5 - Static adapter (SPA mode, SSR disabled)
-- **Vite 6** - Dev server proxies `/api/*` to backend
+- **SvelteKit 2** with Svelte 5 - Static adapter (SPA mode, SSR disabled). All code runs in the browser; there is no server-side rendering.
+- **Vite 6** - Dev and preview servers proxy `/api/*` to backend
 - **TypeScript** - Strict mode enabled
 - **Immer** - Immutable state updates via `produce()`
 - **Quill** - Rich text editing for descriptions
@@ -77,7 +77,7 @@ Located in `/src/lib/models/impl/`. Pure data structures (no fetching/persistenc
 
 ## API Integration
 
-- Dev: Vite proxies `/api/*` to staging backend
+- Localhost: Vite proxies `/api/*` to staging backend (both dev and preview servers)
 - Staging: `https://api.staging-pix.tacocat.com/`
 - Production: `https://api.pix.tacocat.com/`
 

--- a/src/lib/utils/config.ts
+++ b/src/lib/utils/config.ts
@@ -1,4 +1,3 @@
-import { dev } from '$app/environment';
 import type { Rectangle } from '$lib/models/impl/server';
 import { emulateProdOnLocalhost } from './settings';
 import { isValidAlbumPath, isValidImagePath } from './galleryPathUtils';
@@ -19,8 +18,22 @@ function isStaging(): boolean {
     );
 }
 
+/**
+ * Note: This is browser-only (returns false during SSR).
+ * This is safe because the app is a static SPA with no server-side data fetching.
+ * If SSR were enabled, this would need to handle the server-side case.
+ */
+function isLocalhost(): boolean {
+    if (!browser) return false;
+    return window?.location?.hostname === 'localhost' || window?.location?.hostname === '127.0.0.1';
+}
+
 function baseApiUrl(): string {
-    return dev ? '/api/' : isStaging() ? 'https://api.staging-pix.tacocat.com/' : 'https://api.pix.tacocat.com/';
+    // Use proxy path on localhost (works for both dev and preview servers).
+    // Note: This assumes browser-only execution (SPA mode). LAN IPs (e.g., 192.168.x.x)
+    // won't trigger the proxy and will hit staging/prod directly.
+    if (isLocalhost()) return '/api/';
+    return isStaging() ? 'https://api.staging-pix.tacocat.com/' : 'https://api.pix.tacocat.com/';
 }
 function baseAuthApiUrl(): string {
     return isStaging() ? 'https://auth.staging-pix.tacocat.com/' : 'https://auth.pix.tacocat.com/';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,31 @@
 /// <reference types="vitest/config" />
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, type ProxyOptions } from 'vite';
 import { emulateProdOnLocalhost } from './src/lib/utils/settings';
+
+// Shared proxy config for both dev server and preview server
+const apiProxy: Record<string, ProxyOptions> = {
+    '/api': {
+        target: emulateProdOnLocalhost ? 'https://api.pix.tacocat.com/' : 'https://api.staging-pix.tacocat.com/',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+        configure: (proxy, _options) => {
+            proxy.on('error', (err, _req, _res) => {
+                console.log('proxy error', err);
+            });
+            proxy.on('proxyRes', (proxyRes, req, _res) => {
+                if (200 !== proxyRes.statusCode) {
+                    console.log(
+                        'Response from AWS:',
+                        proxyRes.statusCode,
+                        req.url,
+                        JSON.stringify(proxyRes.headers, null, 2),
+                    );
+                }
+            });
+        },
+    },
+};
 
 export default defineConfig({
     plugins: [sveltekit()],
@@ -9,29 +33,9 @@ export default defineConfig({
         include: ['src/**/*.spec.ts'],
     },
     server: {
-        proxy: {
-            '/api': {
-                target: emulateProdOnLocalhost
-                    ? 'https://api.pix.tacocat.com/'
-                    : 'https://api.staging-pix.tacocat.com/',
-                changeOrigin: true,
-                rewrite: (path) => path.replace(/^\/api/, ''),
-                configure: (proxy, _options) => {
-                    proxy.on('error', (err, _req, _res) => {
-                        console.log('proxy error', err);
-                    });
-                    proxy.on('proxyRes', (proxyRes, req, _res) => {
-                        if (200 !== proxyRes.statusCode) {
-                            console.log(
-                                'Response from AWS:',
-                                proxyRes.statusCode,
-                                req.url,
-                                JSON.stringify(proxyRes.headers, null, 2),
-                            );
-                        }
-                    });
-                },
-            },
-        },
+        proxy: apiProxy,
+    },
+    preview: {
+        proxy: apiProxy,
     },
 });


### PR DESCRIPTION
## Problem
E2E tests on localhost were flaky because the preview server didn't have the API proxy configured. When Playwright ran tests against the preview server, the app would try to hit the staging API directly, which failed due to CORS, because staging only allows its own origin.

## Solution
- Configure Vite's `preview.proxy` to share the same proxy config as `server.proxy`
- Change `baseApiUrl()` to detect localhost and use `/api/` path regardless of dev/prod build mode
- Update CLAUDE.md to document the SPA-only architecture and proxy behavior

## Test plan
- [x] `npm run test:e2e` passes consistently (3/3 runs)
- [x] `npm run check` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (22 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the application runs entirely in the browser
  * Updated API proxying behavior for development and preview environments

* **Bug Fixes**
  * Improved API routing to properly handle requests across different environments

* **Refactor**
  * Centralized API proxy configuration for consistency across development and preview servers

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->