### PR TITLE
Change 2026 month bar color to Ice Melt

### DIFF
--- a/src/lib/styles/years.css
+++ b/src/lib/styles/years.css
@@ -8,7 +8,7 @@
     --header-color: #f5ebc7; /* Lemon Icing */
     --sidebar-color: #ccd4dc; /* Rainy Nimbus Cloud */
     --button-color: #ddd3dc; /* Orchid Tint */
-    --month-color: #f5ebc7; /* Lemon Icing */
+    --month-color: #d3e3f2; /* Ice Melt */
 }
 
 .site-container[data-year='2025'] {


### PR DESCRIPTION
## Summary
- Update the month bar color on the 2026 year page from Lemon Icing (#f5ebc7) to Ice Melt (#D3E3F2)
- This change only affects the year page, not week/day pages or photo detail pages

## Test plan
- [ ] Navigate to the 2026 year page and verify month bars display in Ice Melt blue (#D3E3F2)
- [ ] Verify other pages (week, photo detail) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)