### PR TITLE
Fix 2026's --month-color bleeding to all years

### DIFF
--- a/src/lib/styles/years.css
+++ b/src/lib/styles/years.css
@@ -2,7 +2,14 @@
 	Per-year styling
 */
 
-.site-container, /* default colors for years with no styling of their own */
+/* default colors for years with no styling of their own */
+.site-container {
+    --body-color: #f0efeb; /* Cloud Dancer */
+    --header-color: #f5ebc7; /* Lemon Icing */
+    --sidebar-color: #ccd4dc; /* Rainy Nimbus Cloud */
+    --button-color: #ddd3dc; /* Orchid Tint */
+}
+
 .site-container[data-year='2026'] {
     --body-color: #f0efeb; /* Cloud Dancer */
     --header-color: #f5ebc7; /* Lemon Icing */


### PR DESCRIPTION
We were using the current year's colors (currently 2026) also as the color scheme for any year that didn't specify its own colors.  This created a problem in that 2026 specifies a --month-color, which most years don't, so all other years were incorrectly getting that --month color.  This is the color for the month bar on the year album, meaning all other years were incorrectly getting 2026's month bar color.

The solution was to give the default color palette a minimal color scheme that every year will override.  We did this by separating the default `.site-container` styles from 2026-specific styles.

The default color scheme is currently identical to 2026's, minus the month bar color.

This default color scheme currently applies to 1990-2000 and 1969 and older.

## Test plan
- [ ] Verify 2026 year pages show the Ice Melt month color
- [ ] Verify other years (e.g., 2025, 2024) do not have the month color applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved CSS styling structure and organization for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->