### PR TITLE
Separate smoke test into its own CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,14 @@ jobs:
             - name: Deploy to staging
               run: ./deploy_staging.sh
 
+    test-staging:
+        needs: deploy-staging
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:


### PR DESCRIPTION
## Summary
- Split `deploy-staging` job into two separate jobs for better visibility
- New `test-staging` job runs Playwright smoke tests after deploy completes
- Makes it easier to diagnose failures (deploy vs test issues)

## Test plan
- [ ] Verify CI workflow runs all 3 jobs in sequence on merge to main
- [ ] Confirm test-staging job waits for deploy-staging to complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced staging environment verification with automated smoke testing to ensure deployment quality and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->