### PR TITLE
Update default year colors to 2025 colors

### DIFF
--- a/src/lib/styles/years.css
+++ b/src/lib/styles/years.css
@@ -2,12 +2,16 @@
 	Per-year styling
 */
 
-/* default colors for years with no styling of their own */
+/* 
+    Default colors for years with no styling of their own.
+    Make sure this doesn't specify one-off variables like --month-color because
+    those would apply to all years that don't specifically override them.
+*/
 .site-container {
-    --body-color: #f0efeb; /* Cloud Dancer */
-    --header-color: #f5ebc7; /* Lemon Icing */
-    --sidebar-color: #ccd4dc; /* Rainy Nimbus Cloud */
-    --button-color: #ddd3dc; /* Orchid Tint */
+    --body-color: #9d7967; /* Mocha Mousse */
+    --header-color: #efe9e1; /* Gardenia */
+    --sidebar-color: #a59a90; /* Cobblestone */
+    --button-color: #8d9e70; /* Tendril */
 }
 
 .site-container[data-year='2026'] {


### PR DESCRIPTION
## Summary
- Update fallback colors for years without custom styling to use the 2025 palette (Mocha Mousse, Gardenia, Cobblestone, Tendril)
- Improve comment explaining that default colors should not include one-off variables like `--month-color`

## Test plan
- [ ] Verify default colors appear correctly on years without custom styling
- [ ] Confirm 2026 custom colors still work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Default color palette updated to new Mocha/Moss palette affecting body, header, sidebar, and button colors. Year 2026 retains previous colors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->