### PR TITLE
Use GitHub's built-in release notes generator

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+# Configuration for GitHub's auto-generated release notes
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+    categories:
+        - title: ✨ Features & Improvements
+          labels:
+              - enhancement
+              - refactor
+        - title: 🐛 Bug Fixes
+          labels:
+              - bug
+        - title: 📚 Documentation
+          labels:
+              - documentation
+        - title: 🧪 Testing
+          labels:
+              - test
+        - title: 🔄 Other Changes
+          labels:
+              - '*'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -110,7 +110,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
               with:
-                  fetch-depth: 0 # Full history for changelog generation
+                  fetch-depth: 0 # Full history needed to find latest tag
 
             - name: Create release tag
               id: tag
@@ -139,31 +139,11 @@ jobs:
                   git tag -a "$new_tag" -m "Production release $new_tag"
                   git push origin "$new_tag"
 
-            - name: Generate changelog
-              id: changelog
-              run: |
-                  # Get the previous tag (only match YYYYvN format)
-                  prev_tag=$(git tag -l "[0-9][0-9][0-9][0-9]v*" | sort -V | tail -n2 | head -n1)
-                  new_tag="${{ steps.tag.outputs.tag }}"
-
-                  if [ -z "$prev_tag" ] || [ "$prev_tag" = "$new_tag" ]; then
-                      # First release or only one tag
-                      changelog="Initial release"
-                  else
-                      # Generate changelog from commits between tags (inclusive of new tag)
-                      changelog=$(git log --pretty=format:"- %s" "$prev_tag".."$new_tag" 2>/dev/null || echo "- Production deployment")
-                  fi
-
-                  # Write to file to preserve newlines
-                  echo "$changelog" > changelog.txt
-                  echo "Generated changelog from $prev_tag to $new_tag"
-
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v2
               with:
                   tag_name: ${{ steps.tag.outputs.tag }}
                   name: ${{ steps.tag.outputs.tag }}
-                  body_path: changelog.txt
-                  generate_release_notes: false
+                  generate_release_notes: true
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,31 @@ Album data cached in IndexedDB with network fallback.
 - **Pre-commit hooks**: Husky runs gitleaks (secret scanning), lint-staged, type checking, and unit tests on commit. To bypass when needed: `git commit --no-verify`
 - **Gitleaks**: Secret scanner runs on pre-commit. Install with `brew install gitleaks`. The hook warns but continues if gitleaks is not installed.
 
+## Git Amend
+
+`git commit --amend` only amends HEAD (the most recent commit). To amend an older commit, you must use interactive rebase:
+
+```bash
+git rebase -i <commit>^   # Interactive rebase starting from parent of target commit
+# Change "pick" to "edit" for the commit you want to amend
+# Make your changes, then:
+git add <files>
+git commit --amend
+git rebase --continue
+```
+
+## PR Labels
+
+Use labels on pull requests. Apply all labels that fit. Only use the following labels:
+
+- `enhancement` - User-facing features or improvements. Must change production code behavior.
+- `refactor` - Production code changes that don't alter behavior
+- `bug` - Fixes broken production code functionality
+- `test` - Changes to tests
+- `documentation` - Documentation changes
+
+**No label needed** for dependency bumps, CI/CD, tooling, or infrastructure changes - these go in "Other Changes" in release notes.
+
 ## Branch Protection
 
 The `main` branch is protected:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,31 @@ Album data cached in IndexedDB with network fallback.
 - **Pre-commit hooks**: Husky runs gitleaks (secret scanning), lint-staged, type checking, and unit tests on commit. To bypass when needed: `git commit --no-verify`
 - **Gitleaks**: Secret scanner runs on pre-commit. Install with `brew install gitleaks`. The hook warns but continues if gitleaks is not installed.
 
+## Git Amend
+
+`git commit --amend` only amends HEAD (the most recent commit). To amend an older commit, you must use interactive rebase:
+
+```bash
+git rebase -i <commit>^   # Interactive rebase starting from parent of target commit
+# Change "pick" to "edit" for the commit you want to amend
+# Make your changes, then:
+git add <files>
+git commit --amend
+git rebase --continue
+```
+
+## PR Labels
+
+Use labels on pull requests. Apply all labels that fit. Only use the following labels:
+
+- `enhancement` - User-facing features or improvements. Must change production code behavior.
+- `refactor` - Production code changes that don't alter behavior
+- `bug` - Fixes broken production code functionality
+- `test` - Changes to tests
+- `documentation` - Documentation changes
+
+**No label needed** for dependency bumps, CI/CD, tooling, or infrastructure changes - these go in "Other Changes" in release notes.
+
 ## Branch Protection
 
 The `main` branch is protected:

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -146,6 +146,31 @@ START_AGENTS
 - **Pre-commit hooks**: Husky runs gitleaks (secret scanning), lint-staged, type checking, and unit tests on commit. To bypass when needed: `git commit --no-verify`
 - **Gitleaks**: Secret scanner runs on pre-commit. Install with `brew install gitleaks`. The hook warns but continues if gitleaks is not installed.
 
+## Git Amend
+
+`git commit --amend` only amends HEAD (the most recent commit). To amend an older commit, you must use interactive rebase:
+
+```bash
+git rebase -i <commit>^   # Interactive rebase starting from parent of target commit
+# Change "pick" to "edit" for the commit you want to amend
+# Make your changes, then:
+git add <files>
+git commit --amend
+git rebase --continue
+```
+
+## PR Labels
+
+Use labels on pull requests. Apply all labels that fit. Only use the following labels:
+
+- `enhancement` - User-facing features or improvements. Must change production code behavior.
+- `refactor` - Production code changes that don't alter behavior
+- `bug` - Fixes broken production code functionality
+- `test` - Changes to tests
+- `documentation` - Documentation changes
+
+**No label needed** for dependency bumps, CI/CD, tooling, or infrastructure changes - these go in "Other Changes" in release notes.
+
 ## Branch Protection
 
 The `main` branch is protected:

--- a/scripts/build-agent-docs.mjs
+++ b/scripts/build-agent-docs.mjs
@@ -131,12 +131,13 @@ function generateOutput(sourceLines, target) {
 
 /**
  * Clean up excessive empty lines that result from removing blocks.
- * Reduces 3+ consecutive newlines to 2 (one blank line).
+ * - Reduces 3+ consecutive newlines to 2 (one blank line)
+ * - Removes leading blank lines
  * @param {string} content
  * @returns {string}
  */
 function cleanEmptyLines(content) {
-    return content.replace(/\n{3,}/g, '\n\n');
+    return content.replace(/\n{3,}/g, '\n\n').replace(/^\n+/, '');
 }
 
 function main() {


### PR DESCRIPTION
The previous release we had a script that assembled release notes from git commits.  It didn't produce anything readable.  This switches to GitHub's built-in release notes generator.

## Changes
- Switch from manual changelog generation to GitHub's built-in release notes
- Add `.github/release.yml` to configure release note categories by PR label
- Document available PR labels in agent docs

## Test plan
- [ ] Merge PR and deploy to production
- [ ] Verify release notes are auto-generated with proper categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated, structured release-note generation and removed the previous manual changelog step so releases use generated notes.
  * CI now generates release notes automatically.

* **Documentation**
  * Added contributor guidance for amending commits, PR labels, and AI assistant configuration/regeneration.
  * Expanded branch protection and workflow configuration guidance.
  * Normalized documentation output to strip leading blank lines and collapse excessive newlines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->