### PR TITLE
Fix year colors for root album and non-year pages

### DIFF
--- a/src/lib/components/site/SiteLayout.svelte
+++ b/src/lib/components/site/SiteLayout.svelte
@@ -15,12 +15,12 @@
     }
 
     let { hideFooter = false, editControls, children }: Props = $props();
-    let year = $derived(page.params.year || '');
+    let year = $derived(page.params.year || 'current');
 </script>
 
 {@render editControls?.()}
 
-<div class="site-container" data-year={year || null}>
+<div class="site-container" data-year={year}>
     <div class="page-container">
         {@render children?.()}
     </div>

--- a/src/lib/styles/years.css
+++ b/src/lib/styles/years.css
@@ -4,6 +4,7 @@
 
 /* 
     Default colors for years with no styling of their own.
+    This does NOT need to change every year.
     Make sure this doesn't specify one-off variables like --month-color because
     those would apply to all years that don't specifically override them.
 */
@@ -14,6 +15,10 @@
     --button-color: #8d9e70; /* Tendril */
 }
 
+/** 
+    Colors for current year and non-year pages like root album, search, etc. 
+**/
+.site-container[data-year='current'],
 .site-container[data-year='2026'] {
     --body-color: #f0efeb; /* Cloud Dancer */
     --header-color: #f5ebc7; /* Lemon Icing */


### PR DESCRIPTION
Pages not under a year (like the root album and search) weren't getting the current year's styling.   What was happening was that pages without a year param (root album, search, etc.) now use `data-year="current"` which in CSS maps to the current year's color scheme.

This separates "current year" styling from the default fallback styling for years that don't have a color scheme specified, which allows for years with more specific variables like `--month-color` to work correctly without bleeding to other years.

## Test plan
- [ ] Visit root album (`/`) - should show 2026 colors
- [ ] Visit search page - should show 2026 colors
- [ ] Visit a year album (e.g., `/2025/`) - should show that year's colors
- [ ] Visit an older year without `--month-color` - month bar should use `--header-color` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)