### PR TITLE
Add architecture and testing documentation

### DIFF
--- a/.claude/agents/clean-code-reviewer.md
+++ b/.claude/agents/clean-code-reviewer.md
@@ -8,6 +8,15 @@ model: opus
 
 You are a software engineering expert specializing in clean code principles and software craftsmanship for TypeScript and Svelte projects.
 
+## Project Reference
+
+Read `docs/Component_Architecture.md` for project-specific component size guidelines:
+
+- **Small (13-25 lines)**: icons, simple UI elements
+- **Medium (26-50 lines)**: typical component size
+- **Large (51-75 lines)**: page components with routing logic
+- **Extra Large (76+ lines)**: should be reviewed for refactoring
+
 ## Core Mission
 
 Conduct thorough, constructive code reviews that elevate code quality through clean code principles. Focus on maintainability and readability.

--- a/.claude/agents/documentation-reviewer.md
+++ b/.claude/agents/documentation-reviewer.md
@@ -6,13 +6,18 @@ model: opus
 
 You are a documentation quality specialist focused on maintaining consistency between code and project documentation for this SvelteKit photo gallery application.
 
-## Your Documentation Source
+## Your Documentation Sources
 
-Read and reference `CLAUDE.md` as the authoritative source for project patterns.
+Read and reference these as authoritative sources for project patterns:
+
+- `CLAUDE.md` - Primary reference (auto-generated from `docs/AGENTS.src.md`)
+- `docs/Architecture.md` - High-level architecture, caching strategy, design philosophy
+- `docs/Component_Architecture.md` - Component organization, patterns, size guidelines
+- `docs/Svelte.md` - Svelte 5 patterns, state management, TypeScript conventions
 
 **Important:** CLAUDE.md is auto-generated from `docs/AGENTS.src.md`. When suggesting documentation updates, recommend edits to the source file, not CLAUDE.md directly.
 
-Key sections include:
+Key sections in CLAUDE.md include:
 
 - **Build & Development Commands**: npm scripts and their purposes
 - **Tech Stack**: SvelteKit 2, Svelte 5, Vite 6, TypeScript strict mode, Immer, Quill
@@ -101,6 +106,19 @@ Priority: [High/Medium/Low]
 - Uses Vite proxy for `/api/*` in dev
 - `credentials: 'include'` for Cognito auth
 - IndexedDB caching with network fallback
+
+**Architecture Patterns (from docs/Architecture.md):**
+
+- Data caching: Memory → IndexedDB → Server (stale-while-revalidate)
+- Admin code must be lazy-loaded for guest performance
+- Dependency avoidance: libraries must add significant value
+- Speed is a core value
+
+**Component Patterns (from docs/Component_Architecture.md):**
+
+- `/pages/` for routing/loading, `/site/` for reusable UI, `/data-aware/` kept minimal
+- Components over 76 lines should be reviewed for refactoring
+- Admin components lazy-loaded via dynamic imports
 
 ## Review Methodology
 

--- a/.claude/agents/svelte5-reviewer.md
+++ b/.claude/agents/svelte5-reviewer.md
@@ -8,7 +8,12 @@ You are a Svelte 5 and SvelteKit expert specializing in runes, reactivity patter
 
 ## Project Patterns Reference
 
-Read `docs/Svelte.md` for the definitive guide to patterns in this project. Key patterns to enforce:
+Read these docs for project patterns:
+
+- `docs/Svelte.md` - State management, error handling, TypeScript patterns
+- `docs/Component_Architecture.md` - Component organization, size guidelines, composition patterns
+
+Key patterns to enforce:
 
 - Store architecture: state transition methods (public, sync, void) vs service methods (private `#`, async)
 - Private fields use `#` prefix, never `_` or `private` keyword
@@ -213,6 +218,9 @@ albums = produce(albums, (draft) => {
 6. **Store pattern**: Do stores follow state transition vs service method separation?
 7. **Immer usage**: Are complex state updates using `produce()`?
 8. **Route conventions**: Do new routes follow the gallery path system?
+9. **Component organization**: Are components in the right folder (`/pages/`, `/site/`, `/data-aware/`)?
+10. **Component size**: Components over 76 lines should be reviewed for refactoring
+11. **Admin lazy loading**: Are admin components lazy-loaded with dynamic imports?
 
 ## Reporting Format
 

--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ Start development server: `npm run dev`
 1. Create the production assets: `npm run build`
 2. Deploy the build to staging with `npm run deploy-staging` and see results at <https://staging-pix.tacocat.com/>
 3. Deploy the build to production with `npm run deploy-prod` and see results at <https://pix.tacocat.com/>
+
+## More Info
+
+- [Architecture](docs/Architecture.md)
+- [Component Architecture](docs/Component_Architecture.md)
+- [Testing](docs/Testing.md)
+- [Svelte 5 Patterns](docs/Svelte.md)

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,104 @@
+# Architecture
+
+## Basic Architecture
+
+This is a single page app (SPA) built in SvelteKit and TypeScript. It does not use Sveltekit's server-side rendering; instead, the static browser-side files are deployed to a webserver. The webserver config is a separate project.
+
+## The Back End is Elsewhere
+
+This project only contains the static Single Page App (SPA) assets; the back end infrastructure for the app is contained in other projects. That includes:
+
+- The hosting of this web app
+- The back end photo management: photo storage, database, search, user management, image manipulation
+
+## State Management
+
+We use a state machine pattern for complex state management. The state machines are in `src/lib/stores/` and are organized by domain, such as:
+
+- `AlbumState`: Manages album data and loading states
+- `SessionStore`: Handles user session information
+- `SearchStore`: Manages search state and results
+
+Each state machine has clear separation between:
+
+- _State Transition Methods_: These are the only public methods that can update state. They are synchronous and return void. They should return near-instantly.
+- _Service Methods_: These are private methods that do the actual work (like making server calls). They are generally async and don't mutate state directly.
+- _Other Methods_: Utility methods that don't fit the above categories.
+
+We do not use a state machine library; we evaluated several of the front-runners and determined the download weight and complexity weren't worth it.
+
+State is stored in \*.svelte.ts classes. These are compiled by Svelte and use Svelte 5's rune-based reactive state system with `$state` and `$derived`. We do NOT use Svelte stores.
+
+For detailed patterns and code examples, see [Svelte 5 Patterns](Svelte.md#store-architecture).
+
+## Data Caching Strategy
+
+For retrieving albums and other data from the server, we use a Cache-Then-Network aka Stale-While-Revalidate pattern:
+
+1. _Memory Cache_: The first layer is in-memory state. If data is already loaded in the application state, we return it immediately and then refresh in the background.
+
+2. _Disk Cache_: If data isn't in memory, we check IndexedDB. If found, we return it immediately and then refresh in the background.
+
+3. _Server Fetch_: In both cases above, we make a network request in the background to ensure data freshness.
+    - On success, update the in-memory state first (prioritize showing new info to the user the fastest), then write to IndexedDB
+    - On 404, remove it from all the caches.
+    - On any other server error, keep the cached version.
+
+This strategy ensures:
+
+- Fast initial loads from cache
+- Always-fresh data through background updates
+- Some measure of offline capability / graceful degradation when network is unavailable
+
+## User Model
+
+- _End users_: the audience that uses this web app are unauthenticated guest users; we do not want people to have to manage logins.
+- _Admins_: the administrators of the site, the people who upload images and edit albums, each get their own login.
+
+## Lazy Loading
+
+We want the unauthenticated guest experience to be as fast as possible. Therefore we use lazy loading techniques to ensure that guests don't download any of the admin code.
+
+This often looks like this: ` {#await import('$lib/components/site/admin/SomeAdminComponent.svelte') then { default: SomeAdminComponent }}`
+
+## Hidden from Search Engines
+
+The photos displayed through the app are personal in nature, and we do not want the wider internet to find them. However, we also don't want our audience to have to manage logins. Therefore, this app is designed to be publicly accessible yet NOT discoverable via Google and other search engines. This allows our unauthenticated guest users to use it, but casual searchers will not find it. Our users are notified of new albums via out-of-band mechanisms not discussed here.
+
+We implement this by including `<meta name="robots" content="noindex" />` in every page view. This is more effective than the historical practice of using a robots.txt file.
+
+Therefore, we do NOT care about Search Engine Optimization (SEO). Some features you might expect, like SEO-related meta tags, don't exist for this reason. Anything we can drop makes the app faster for end users.
+
+## Browser Compatibility
+
+- We ensure compatibility with major browsers (Chrome, Firefox, Safari) on both desktop and mobile.
+- We ensure that any browser that hasn't been updated in two years still works. So HTML5, but not bleeding edge HTML5.
+- We do NOT support Internet Explorer (IE).
+
+## We Avoid Dependencies
+
+We avoid dependencies whenever possible, especially runtime dependencies. We are very careful and parsimonious about adding new dependencies / libraries to the project. A library has to add a LOT of value to be worth it.
+
+We avoid dependencies because:
+
+- _Complexity_
+    - Every dependency adds more moving parts to the system. More things to go stale / break with non-backwards-compatible updates, more subsystems to have to understand.
+- _Weight_
+    - Every dependency makes it heavier to download. In particular, we don't want to add weight for guest users. Speed is one of the most important virtues of this app.
+
+If we _must_ add a dependency, we look for:
+
+- _Zero sub-dependencies_
+    - We go out of our way to use libraries that themselves don't have dependencies
+- _Small size_
+    - We prefer libraries with smaller bundled, minified size to client
+
+## Speed is an Obsession
+
+We prioritize a blazing fast user experience. Examples of choices we've made in support of this:
+
+- We chose Svelte and Sveltekit in part because they have one of the lightest weight downloads of the major web application frameworks.
+- The aforementioned ruthless elimination of dependencies.
+- The aforementioned lazy loading of admin functionality.
+- We've done extensive work to optimize the caching architecture: caching of the web app binaries, caching of API calls where appropriate, caching of images, etc
+- It's not in this project, but our choices around databases, Content Delivery Networks (CDNs) and other back end infrastructure were driven in large part by performance considerations

--- a/docs/Component_Architecture.md
+++ b/docs/Component_Architecture.md
@@ -1,0 +1,164 @@
+# Component Architecture & Patterns
+
+We use Svelte 5 components and Sveltekit.
+
+## Component Organization
+
+The main categories of components are organized by folder:
+
+1. **`/pages/`** - Page-level components that handle routing, UI states and loading the page's data
+
+    - Organized by domain (album, image, search, admin)
+    - Contains routing logic and loading/error states
+    - Examples: `AlbumLoadingPage.svelte`, `AlbumErrorPage.svelte`
+
+2. **`/site/`** - Reusable UI components that are composed into user experiences by the `/pages/`
+
+    - Layout components (`SiteLayout.svelte`, `Header.svelte`)
+    - Navigation components (`nav/` subdirectory)
+    - Icon components (`icons/` subdirectory)
+    - Admin-specific components (`admin/` subdirectory)
+    - Except for the `admin/` components, these are **data-agnostic** by default, and do not interact with state machines
+
+3. **`/data-aware/`** - Components that fetch their own data, rather than letting a page in '/pages/' do it
+    - We want to keep these to an absolutely minimum. Do not add any more of these.
+    - Examples: `LatestAlbumThumbnail.svelte`
+
+## Key Architectural Patterns
+
+### State Machine Integration
+
+- Components are **data-agnostic** by default, except for the `admin/` components
+- State machines handle all data fetching, caching, and state transitions
+- Components consume state through reactive `$derived` expressions
+
+### Snippet-Based Composition
+
+- Uses Svelte 5's `Snippet` type for flexible component composition
+- Components accept `children?: Snippet` for content injection
+- Allows for dynamic content rendering with `{@render children?.()}`
+- Enables flexible layouts without tight coupling
+
+### Props Interface Pattern
+
+- All components use TypeScript interfaces for props
+- Props are destructured with `$props()` and default values
+- Clear documentation of prop purposes in JSDoc comments
+- Optional props with sensible defaults
+
+### Status-Based Routing
+
+- Page components use status-based conditional rendering
+- Clear separation between loading, error, and success states
+- Consistent error handling patterns across the application
+- Route pages (e.g., `src/routes/[year=year]/+page.svelte`) handle all album states
+
+### Admin/Guest Separation
+
+- Guest users, who have read-only access to the app, are not made to download the admin functionality. Admin components are lazy-loaded via dynamic imports like `{#await import('$lib/components/site/admin/SomeAdminComponent.svelte') then { default: SomeAdminComponent }}`
+- Admin functionality is isolated in `/site/admin/` directory
+
+## Component Communication Patterns
+
+### Parent-Child Communication
+
+- Props down, events up pattern
+- Snippets for flexible content injection
+- No direct state manipulation in child components
+
+### Cross-Component Communication
+
+- State machines handle all cross-component communication
+- Components react to state changes through `$derived`
+- No direct component-to-component communication
+
+### Admin Component Patterns
+
+- Admin components integrate with specific state machines
+- Edit controls use draft machines for temporary state
+- Consistent patterns for edit/delete/create operations
+
+## Styling Patterns
+
+### CSS Custom Properties
+
+- Uses CSS custom properties for theming (`--default-border`, `--header-color`)
+- Consistent spacing and color variables
+- Responsive design with utility classes (`hidden-sm`, `hidden-xs`)
+
+### Component-Scoped Styles
+
+- Each component has its own `<style>` block
+- No global CSS pollution
+- Consistent naming conventions
+
+## Best Practices
+
+1. **Single Responsibility**: Each component has a clear, focused purpose
+2. **Composition over Inheritance**: Uses snippets and props for flexibility
+3. **State Isolation**: Components don't directly manage complex state
+4. **Performance**: Lazy loading of admin components
+5. **Accessibility**: Proper alt text, semantic HTML
+6. **Error Boundaries**: Clear error states and recovery paths
+
+## Development Guidelines
+
+- Use TypeScript interfaces for all props
+- Document component purposes with JSDoc comments
+- Use state machines for data management
+- Implement proper loading and error states
+- Components in the `/site/` directory should be composable and reusable
+
+## Component Size Guidelines
+
+Keep components brief. A component should do only one thing. Guidelines:
+
+- **Small (13-25 lines)**: icons, simple UI elements
+- **Medium (26-50 lines)**: typical component size
+- **Large (51-75 lines)**: page components with routing logic
+- **Extra Large (76+ lines)**: should be reviewed for refactoring
+
+## Naming Conventions
+
+### Component Files
+
+- Use PascalCase for component file names: `Header.svelte`, `AlbumThumbnail.svelte`
+- Use descriptive names that indicate the component's purpose
+- Page components end with `Page.svelte`: `AlbumPage.svelte`, `SearchPage.svelte`
+- Layout components end with `Layout.svelte`: `SiteLayout.svelte`, `AlbumPageLayout.svelte`
+- Icon components end with `Icon.svelte`: `HomeIcon.svelte`, `SearchIcon.svelte`
+
+### Props Interface
+
+- Always name the props interface `Props`
+- Use JSDoc comments to document each prop's purpose
+- Use descriptive prop names that clearly indicate their function
+- Use optional props with sensible defaults
+
+### Component Documentation
+
+- Start each component with a `@component` JSDoc comment
+- Include a brief description of the component's purpose
+- Example:
+
+    ```typescript
+    <!--
+      @component
+
+      Header of the site
+    -->
+    ```
+
+### Variable Naming
+
+- Use camelCase for variables and functions
+- Use descriptive names that indicate purpose
+- Use `$derived` for reactive expressions
+- Use `$state` for component state
+
+### CSS Classes
+
+- Use kebab-case for CSS class names
+- Use semantic class names that describe the element's purpose
+- Use utility classes for common patterns (`hidden-sm`, `hidden-xs`)
+- Use CSS custom properties for theming values

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,0 +1,391 @@
+# Testing Guide
+
+Best practices and patterns for writing tests in this project.
+
+## Test Organization
+
+### Group Related Functionality
+
+```typescript
+describe('ComponentOrModule', () => {
+    describe('primaryMethod', () => {
+        // All tests for primaryMethod grouped together
+    });
+
+    describe('secondaryMethod', () => {
+        // All tests for secondaryMethod grouped together
+    });
+});
+```
+
+### Test Naming Convention
+
+Use the `it('should...')` format for test descriptions:
+
+```typescript
+// ✅ Good: Clear, descriptive test names
+it('should return formatted title when given valid filename', () => { ... });
+it('should throw error when input is invalid', () => { ... });
+it('should handle async operations correctly', async () => { ... });
+
+// ❌ Bad: Vague or non-descriptive names
+it('works', () => { ... });
+it('test title function', () => { ... });
+it('handles errors', () => { ... });
+```
+
+## Helper Functions
+
+### Common Assertions
+
+Extract frequently used assertions into reusable helper functions:
+
+```typescript
+function expectApiCalledWith(path: string) {
+    expect(mockApi).toHaveBeenCalled();
+    expect(mockApi.mock.calls.some((call) => call[0].includes(path))).toBe(true);
+}
+
+function expectElementVisible(element: HTMLElement) {
+    expect(element).toBeInTheDocument();
+    expect(element).toBeVisible();
+}
+```
+
+### Mock Setup Helpers
+
+Create helper functions for common mock configurations:
+
+```typescript
+function mockApiSuccess(response: ApiResponse) {
+    mockApi.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(response),
+    });
+}
+
+function mockApiError(status: number, message: string) {
+    mockApi.mockResolvedValueOnce({
+        ok: false,
+        status,
+        json: () => Promise.resolve({ error: message }),
+    });
+}
+```
+
+**Benefits:**
+
+- Reduces code duplication
+- Improves test readability
+- Centralizes mock configuration
+- Makes tests more maintainable
+
+## Async Testing
+
+### Use vi.waitFor() Instead of Delays
+
+```typescript
+// ✅ Good: Wait for specific condition
+await vi.waitFor(
+    () => {
+        expect(element).toBeVisible();
+    },
+    { timeout: TEST_TIMEOUT },
+);
+
+// ❌ Bad: Arbitrary delay
+await new Promise((resolve) => setTimeout(resolve, 100));
+```
+
+### Test Async Error Conditions
+
+```typescript
+it('should handle async errors gracefully', async () => {
+    // Arrange: Set up error condition
+    mockApiError(500, 'Server error');
+
+    // Act: Trigger async operation
+    const promise = asyncFunction();
+
+    // Assert: Wait for error handling
+    await expect(promise).rejects.toThrow('Server error');
+});
+```
+
+## Error Testing
+
+### Synchronous Errors
+
+```typescript
+it('should throw error for invalid input', () => {
+    const invalidInput = 'invalid-input';
+
+    expect(() => {
+        processInput(invalidInput);
+    }).toThrow(`Invalid input: ${invalidInput}`);
+});
+```
+
+### Asynchronous Errors
+
+```typescript
+it('should reject promise for invalid async operation', async () => {
+    const invalidPath = 'invalid-path';
+
+    await expect(asyncOperation(invalidPath)).rejects.toThrow(`Invalid path: ${invalidPath}`);
+});
+```
+
+## Mocking Strategies
+
+### Consistent Mock Patterns
+
+```typescript
+// ✅ Good: Use mockResolvedValueOnce for single-use mocks
+mockApi.mockResolvedValueOnce({ ok: true, data: mockData });
+
+// ✅ Good: Use mockResolvedValue for reusable mocks
+function mockApiSuccess() {
+    mockApi.mockResolvedValue({ ok: true, data: mockData });
+}
+
+// ❌ Avoid: Mixing patterns inconsistently
+mockApi.mockResolvedValueOnce({ ok: true }); // Sometimes
+mockApi.mockResolvedValue({ ok: false }); // Sometimes
+```
+
+### Mock Cleanup
+
+```typescript
+beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear any other state as needed
+});
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Inconsistent Test Structure
+
+Follow the Arrange-Act-Assert (AAA) pattern:
+
+```typescript
+// ❌ Bad: Inconsistent arrangement
+it('should do something', async () => {
+    const data = createData();
+    setup(data);
+    const result = await processData(data);
+    expect(result).toBe(true);
+});
+
+// ✅ Good: Clear AAA pattern
+it('should do something', async () => {
+    // Arrange
+    const data = createData();
+    setup(data);
+
+    // Act
+    const result = await processData(data);
+
+    // Assert
+    expect(result).toBe(true);
+});
+```
+
+### 2. Undocumented "Magic" Numbers
+
+```typescript
+// ❌ Bad: Undocumented magic number
+const TEST_TIMEOUT = 1000;
+
+// ✅ Good: Documented timeout with explanation
+const TEST_TIMEOUT = 1000; // 1 second timeout for async operations
+```
+
+### 3. Missing Test Documentation
+
+```typescript
+// ❌ Bad: No explanation of what's being tested
+it('should handle loading', async () => { ... });
+
+// ✅ Good: Clear test description
+it('should show loading spinner while data is being fetched', async () => { ... });
+```
+
+### 4. Testing Implementation Details
+
+```typescript
+// ❌ Bad: Testing internal implementation
+expect(component['privateMethod']).toHaveBeenCalled();
+
+// ✅ Good: Testing public behavior
+expect(screen.getByText('Expected output')).toBeInTheDocument();
+```
+
+## Testing Templates
+
+### Basic Template
+
+```typescript
+it('should EXPECTED_BEHAVIOR when CONDITION', () => {
+    // Arrange: Set up test data and environment
+    const input = 'test-input';
+    const expected = 'expected-output';
+
+    // Act: Execute the functionality
+    const result = functionUnderTest(input);
+
+    // Assert: Verify the outcome
+    expect(result).toBe(expected);
+});
+```
+
+### Async Template
+
+```typescript
+it('should EXPECTED_BEHAVIOR when CONDITION', async () => {
+    // Arrange: Set up test data and mocks
+    const input = 'test-input';
+    mockApiSuccess(mockResponse);
+
+    // Act: Execute async functionality
+    const result = await asyncFunction(input);
+
+    // Assert: Verify the outcome
+    expect(result).toBeDefined();
+    expect(mockApi).toHaveBeenCalledWith(input);
+});
+```
+
+### Error Testing Template
+
+```typescript
+it('should throw ERROR_TYPE when INVALID_INPUT', () => {
+    // Arrange: Set up invalid input
+    const invalidInput = 'invalid-input';
+
+    // Act & Assert: Verify error is thrown
+    expect(() => {
+        functionUnderTest(invalidInput);
+    }).toThrow(`Expected error message: ${invalidInput}`);
+});
+```
+
+### Async Error Testing Template
+
+```typescript
+it('should handle async error when CONDITION', async () => {
+    // Arrange: Set up error condition
+    const input = 'test-input';
+    mockApiError(500, 'Server error');
+
+    // Act & Assert: Verify error handling
+    await expect(asyncFunction(input)).rejects.toThrow('Server error');
+});
+```
+
+## End-to-End Testing with Playwright
+
+### Before Writing E2E Tests
+
+**ALWAYS examine the actual DOM structure** before writing Playwright tests. Avoid assumptions about CSS classes, element hierarchy, or component structure.
+
+#### 1. Inspect Components First
+
+Before writing selectors, examine the actual components:
+
+```bash
+# Look at page components to understand routing
+find src/lib/components/pages -name "*.svelte" | head -5
+
+# Look at site components for UI structure
+find src/lib/components/site -name "*.svelte" | head -10
+
+# Check routes for available URLs
+ls src/routes/
+```
+
+#### 2. Use Browser DevTools
+
+- Navigate to pages manually in browser
+- Inspect actual DOM elements and their attributes
+- Note CSS classes, `data-*` attributes, ARIA labels
+- Test responsive behavior at different viewport sizes
+
+#### 3. Look for Test-Friendly Attributes
+
+Prioritize selectors in this order:
+
+```typescript
+// ✅ Best: Test-specific attributes
+page.getByTestId('album-thumbnail');
+page.getByRole('button', { name: 'Upload Photo' });
+
+// ✅ Good: Semantic attributes
+page.getByRole('link', { name: /home/i });
+page.getByLabel('Search photos');
+
+// ⚠️ Okay: Stable CSS classes (if semantic attributes unavailable)
+page.locator('.album-grid');
+
+// ❌ Avoid: Generic or implementation-specific selectors
+page.locator('div.css-xyz123');
+page.locator('button:nth-child(3)');
+```
+
+#### 4. Verify Routes Exist
+
+Check routing structure before writing navigation tests:
+
+```typescript
+// Check actual routes in src/routes/ directory
+// Don't assume URLs like '/albums/123' exist without verification
+```
+
+### E2E Test Structure
+
+#### Arrange-Act-Assert for E2E
+
+```typescript
+test('should navigate through photo gallery', async ({ page }) => {
+    // Arrange: Set up initial state
+    await page.goto('/');
+
+    // Act: Perform user interactions
+    await page.getByRole('link', { name: /albums/i }).click();
+    await page.getByTestId('album-thumbnail').first().click();
+
+    // Assert: Verify expected outcomes
+    await expect(page).toHaveURL(/\/album\/\d+/);
+    await expect(page.getByRole('heading')).toBeVisible();
+});
+```
+
+#### Wait for Dynamic Content
+
+```typescript
+// ✅ Good: Wait for specific content
+await page.waitForLoadState('networkidle');
+await expect(page.getByTestId('photo-grid')).toBeVisible();
+
+// ✅ Good: Wait for API calls to complete
+await page.waitForResponse((response) => response.url().includes('/api/albums'));
+
+// ❌ Bad: Arbitrary waits
+await page.waitForTimeout(2000);
+```
+
+#### Mobile-Responsive Testing
+
+```typescript
+test('should work on mobile devices', async ({ page }) => {
+    // Set mobile viewport
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    await page.goto('/');
+
+    // Test mobile-specific UI elements
+    await expect(page.getByTestId('mobile-menu-toggle')).toBeVisible();
+    await expect(page.getByTestId('desktop-nav')).not.toBeVisible();
+});
+```


### PR DESCRIPTION
## Summary

- Cherry-picked documentation from `main-backup-pre-2026-jan` branch that accurately describes main's current codebase
- Updated pre-PR review agents to reference the new docs
- Added "More Info" section to README

## New Documentation

- **docs/Architecture.md**: High-level architecture, caching strategy (Memory → IndexedDB → Server), design philosophy (speed, avoid dependencies, lazy loading)
- **docs/Component_Architecture.md**: Component organization (`/pages/`, `/site/`, `/data-aware/`), size guidelines, composition patterns
- **docs/Testing.md**: Testing best practices for Vitest unit tests and Playwright E2E tests

## Agent Updates

- **svelte5-reviewer**: Now checks component organization, size (76+ line threshold), and admin lazy loading
- **documentation-reviewer**: Now validates architecture and component patterns
- **clean-code-reviewer**: Now uses project-specific component size guidelines

## Test plan

- [ ] Verify doc links in README work
- [ ] Run `/pre-pr-check` on a future PR to confirm agents reference new docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Architecture documentation covering SPA design, state management, caching strategies, and performance considerations.
  * Created Component Architecture guide with organization patterns, size guidelines, and best practices.
  * Introduced Testing Guide with unit and E2E testing patterns, naming conventions, and code examples.
  * Enhanced reviewer guidance with clearer pattern references and expanded checklists.
  * Added links to new documentation resources in project README.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->