### PR TITLE
Major package bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
             "license": "MIT",
             "dependencies": {
                 "idb-keyval": "^6.2.2",
-                "immer": "^10.1.1",
+                "immer": "^11.1.3",
                 "quill": "^2.0.3",
-                "svelte-easy-crop": "^4.0.0"
+                "svelte-easy-crop": "^5.0.0"
             },
             "devDependencies": {
                 "@eslint/js": "^9.39.2",
@@ -24,19 +24,19 @@
                 "eslint": "^9.39.2",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-prettier": "^5.5.4",
-                "eslint-plugin-svelte": "^2.46.1",
+                "eslint-plugin-svelte": "^3.13.1",
                 "husky": "^9.1.7",
                 "lint-staged": "^16.2.7",
                 "prettier": "^3.7.4",
                 "prettier-plugin-svelte": "^3.4.1",
                 "svelte": "^5.46.1",
                 "svelte-check": "^4.3.5",
-                "svelte-eslint-parser": "^0.43.0",
+                "svelte-eslint-parser": "^1.4.1",
                 "svelte-preprocess": "^6.0.3",
                 "tslib": "^2.8.1",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.52.0",
-                "vite": "^6.1.0",
+                "vite": "^7.3.0",
                 "vitest": "^4.0.16"
             },
             "engines": {
@@ -44,9 +44,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+            "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
             "cpu": [
                 "ppc64"
             ],
@@ -61,9 +61,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+            "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
             "cpu": [
                 "arm"
             ],
@@ -78,9 +78,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+            "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
             "cpu": [
                 "arm64"
             ],
@@ -95,9 +95,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+            "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
             "cpu": [
                 "x64"
             ],
@@ -112,9 +112,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+            "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
             "cpu": [
                 "arm64"
             ],
@@ -129,9 +129,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+            "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
             "cpu": [
                 "x64"
             ],
@@ -146,9 +146,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
             "cpu": [
                 "arm64"
             ],
@@ -163,9 +163,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+            "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
             "cpu": [
                 "x64"
             ],
@@ -180,9 +180,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+            "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
             "cpu": [
                 "arm"
             ],
@@ -197,9 +197,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+            "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
             "cpu": [
                 "arm64"
             ],
@@ -214,9 +214,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+            "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
             "cpu": [
                 "ia32"
             ],
@@ -231,9 +231,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+            "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
             "cpu": [
                 "loong64"
             ],
@@ -248,9 +248,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+            "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
             "cpu": [
                 "mips64el"
             ],
@@ -265,9 +265,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+            "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -282,9 +282,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+            "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
             "cpu": [
                 "riscv64"
             ],
@@ -299,9 +299,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+            "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
             "cpu": [
                 "s390x"
             ],
@@ -316,9 +316,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+            "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
             "cpu": [
                 "x64"
             ],
@@ -333,9 +333,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
             "cpu": [
                 "arm64"
             ],
@@ -350,9 +350,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+            "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
             "cpu": [
                 "x64"
             ],
@@ -367,9 +367,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
             "cpu": [
                 "arm64"
             ],
@@ -384,9 +384,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+            "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
             "cpu": [
                 "x64"
             ],
@@ -401,9 +401,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+            "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
             "cpu": [
                 "arm64"
             ],
@@ -418,9 +418,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+            "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
             "cpu": [
                 "x64"
             ],
@@ -435,9 +435,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+            "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
             "cpu": [
                 "arm64"
             ],
@@ -452,9 +452,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+            "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
             "cpu": [
                 "ia32"
             ],
@@ -469,9 +469,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+            "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
             "cpu": [
                 "x64"
             ],
@@ -2046,9 +2046,9 @@
             "license": "MIT"
         },
         "node_modules/esbuild": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+            "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -2059,32 +2059,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.12",
-                "@esbuild/android-arm": "0.25.12",
-                "@esbuild/android-arm64": "0.25.12",
-                "@esbuild/android-x64": "0.25.12",
-                "@esbuild/darwin-arm64": "0.25.12",
-                "@esbuild/darwin-x64": "0.25.12",
-                "@esbuild/freebsd-arm64": "0.25.12",
-                "@esbuild/freebsd-x64": "0.25.12",
-                "@esbuild/linux-arm": "0.25.12",
-                "@esbuild/linux-arm64": "0.25.12",
-                "@esbuild/linux-ia32": "0.25.12",
-                "@esbuild/linux-loong64": "0.25.12",
-                "@esbuild/linux-mips64el": "0.25.12",
-                "@esbuild/linux-ppc64": "0.25.12",
-                "@esbuild/linux-riscv64": "0.25.12",
-                "@esbuild/linux-s390x": "0.25.12",
-                "@esbuild/linux-x64": "0.25.12",
-                "@esbuild/netbsd-arm64": "0.25.12",
-                "@esbuild/netbsd-x64": "0.25.12",
-                "@esbuild/openbsd-arm64": "0.25.12",
-                "@esbuild/openbsd-x64": "0.25.12",
-                "@esbuild/openharmony-arm64": "0.25.12",
-                "@esbuild/sunos-x64": "0.25.12",
-                "@esbuild/win32-arm64": "0.25.12",
-                "@esbuild/win32-ia32": "0.25.12",
-                "@esbuild/win32-x64": "0.25.12"
+                "@esbuild/aix-ppc64": "0.27.2",
+                "@esbuild/android-arm": "0.27.2",
+                "@esbuild/android-arm64": "0.27.2",
+                "@esbuild/android-x64": "0.27.2",
+                "@esbuild/darwin-arm64": "0.27.2",
+                "@esbuild/darwin-x64": "0.27.2",
+                "@esbuild/freebsd-arm64": "0.27.2",
+                "@esbuild/freebsd-x64": "0.27.2",
+                "@esbuild/linux-arm": "0.27.2",
+                "@esbuild/linux-arm64": "0.27.2",
+                "@esbuild/linux-ia32": "0.27.2",
+                "@esbuild/linux-loong64": "0.27.2",
+                "@esbuild/linux-mips64el": "0.27.2",
+                "@esbuild/linux-ppc64": "0.27.2",
+                "@esbuild/linux-riscv64": "0.27.2",
+                "@esbuild/linux-s390x": "0.27.2",
+                "@esbuild/linux-x64": "0.27.2",
+                "@esbuild/netbsd-arm64": "0.27.2",
+                "@esbuild/netbsd-x64": "0.27.2",
+                "@esbuild/openbsd-arm64": "0.27.2",
+                "@esbuild/openbsd-x64": "0.27.2",
+                "@esbuild/openharmony-arm64": "0.27.2",
+                "@esbuild/sunos-x64": "0.27.2",
+                "@esbuild/win32-arm64": "0.27.2",
+                "@esbuild/win32-ia32": "0.27.2",
+                "@esbuild/win32-x64": "0.27.2"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -2161,22 +2161,6 @@
                 }
             }
         },
-        "node_modules/eslint-compat-utils": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
-            "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "peerDependencies": {
-                "eslint": ">=6.0.0"
-            }
-        },
         "node_modules/eslint-config-prettier": {
             "version": "10.1.8",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
@@ -2226,38 +2210,50 @@
             }
         },
         "node_modules/eslint-plugin-svelte": {
-            "version": "2.46.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.46.1.tgz",
-            "integrity": "sha512-7xYr2o4NID/f9OEYMqxsEQsCsj4KaMy4q5sANaKkAb6/QeCjYFxRmDm2S3YC3A3pl1kyPZ/syOx/i7LcWYSbIw==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.13.1.tgz",
+            "integrity": "sha512-Ng+kV/qGS8P/isbNYVE3sJORtubB+yLEcYICMkUWNaDTb0SwZni/JhAYXh/Dz/q2eThUwWY0VMPZ//KYD1n3eQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@jridgewell/sourcemap-codec": "^1.4.15",
-                "eslint-compat-utils": "^0.5.1",
+                "@eslint-community/eslint-utils": "^4.6.1",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "esutils": "^2.0.3",
-                "known-css-properties": "^0.35.0",
-                "postcss": "^8.4.38",
+                "globals": "^16.0.0",
+                "known-css-properties": "^0.37.0",
+                "postcss": "^8.4.49",
                 "postcss-load-config": "^3.1.4",
-                "postcss-safe-parser": "^6.0.0",
-                "postcss-selector-parser": "^6.1.0",
-                "semver": "^7.6.2",
-                "svelte-eslint-parser": "^0.43.0"
+                "postcss-safe-parser": "^7.0.0",
+                "semver": "^7.6.3",
+                "svelte-eslint-parser": "^1.4.0"
             },
             "engines": {
-                "node": "^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ota-meshi"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0-0 || ^9.0.0-0",
+                "eslint": "^8.57.1 || ^9.0.0",
                 "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
             },
             "peerDependenciesMeta": {
                 "svelte": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-plugin-svelte/node_modules/globals": {
+            "version": "16.5.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+            "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint-scope": {
@@ -2583,9 +2579,9 @@
             }
         },
         "node_modules/immer": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-            "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
+            "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -2739,9 +2735,9 @@
             }
         },
         "node_modules/known-css-properties": {
-            "version": "0.35.0",
-            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
-            "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
+            "version": "0.37.0",
+            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+            "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3254,20 +3250,30 @@
             }
         },
         "node_modules/postcss-safe-parser": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-            "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+            "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "license": "MIT",
             "engines": {
-                "node": ">=12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/postcss/"
+                "node": ">=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.3.3"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-scss": {
@@ -3298,9 +3304,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-            "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3778,29 +3784,31 @@
             }
         },
         "node_modules/svelte-easy-crop": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/svelte-easy-crop/-/svelte-easy-crop-4.0.1.tgz",
-            "integrity": "sha512-0k7vVpHVLrPyobSXqey5IJUmFVxOoCaQrobFEsFXpSCyK8N5jTkRj1VX6NuCOZK8XXcMAqUvV0MktB8D5x1oCw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/svelte-easy-crop/-/svelte-easy-crop-5.0.0.tgz",
+            "integrity": "sha512-niWtner+qYVas6ypIOQ277NKNACVz9qz6wfpEW7t+x5Lhv6nOjpv3S1WhEPO+SnDaW3VZv+0bmm6jVDHK2GMAg==",
             "license": "MIT",
             "peerDependencies": {
                 "svelte": "^5.0.0"
             }
         },
         "node_modules/svelte-eslint-parser": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.43.0.tgz",
-            "integrity": "sha512-GpU52uPKKcVnh8tKN5P4UZpJ/fUDndmq7wfsvoVXsyP+aY0anol7Yqo01fyrlaWGMFfm4av5DyrjlaXdLRJvGA==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.1.tgz",
+            "integrity": "sha512-1eqkfQ93goAhjAXxZiu1SaKI9+0/sxp4JIWQwUpsz7ybehRE5L8dNuz7Iry7K22R47p5/+s9EM+38nHV2OlgXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "eslint-scope": "^7.2.2",
-                "eslint-visitor-keys": "^3.4.3",
-                "espree": "^9.6.1",
-                "postcss": "^8.4.39",
-                "postcss-scss": "^4.0.9"
+                "eslint-scope": "^8.2.0",
+                "eslint-visitor-keys": "^4.0.0",
+                "espree": "^10.0.0",
+                "postcss": "^8.4.49",
+                "postcss-scss": "^4.0.9",
+                "postcss-selector-parser": "^7.0.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
+                "pnpm": "10.24.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ota-meshi"
@@ -3812,54 +3820,6 @@
                 "svelte": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/svelte-eslint-parser/node_modules/eslint-scope": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/svelte-eslint-parser/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/svelte-eslint-parser/node_modules/espree": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "acorn": "^8.9.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/svelte-preprocess": {
@@ -4130,25 +4090,25 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
+            "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "esbuild": "^0.25.0",
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.3",
-                "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.13"
+                "esbuild": "^0.27.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -4157,14 +4117,14 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@types/node": "^20.19.0 || >=22.12.0",
                 "jiti": ">=1.21.0",
-                "less": "*",
+                "less": "^4.0.0",
                 "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
                 "yaml": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -46,26 +46,26 @@
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
-        "eslint-plugin-svelte": "^2.46.1",
+        "eslint-plugin-svelte": "^3.13.1",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "prettier": "^3.7.4",
         "prettier-plugin-svelte": "^3.4.1",
         "svelte": "^5.46.1",
         "svelte-check": "^4.3.5",
-        "svelte-eslint-parser": "^0.43.0",
+        "svelte-eslint-parser": "^1.4.1",
         "svelte-preprocess": "^6.0.3",
         "tslib": "^2.8.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.52.0",
-        "vite": "^6.1.0",
+        "vite": "^7.3.0",
         "vitest": "^4.0.16"
     },
     "dependencies": {
         "idb-keyval": "^6.2.2",
-        "immer": "^10.1.1",
+        "immer": "^11.1.3",
         "quill": "^2.0.3",
-        "svelte-easy-crop": "^4.0.0"
+        "svelte-easy-crop": "^5.0.0"
     },
     "engineStrict": true,
     "engines": {


### PR DESCRIPTION
Bump major versions of packages:
- Vite 6.1 → 7.3
- Immer 10.1 → 11.1
- eslint-plugin-svelte 2.46 → 3.13
- svelte-eslint-parser 0.43 → 1.4
- svelte-easy-crop 4.0 → 5.0

No code changes required or desirable - all APIs remain compatible and not deprecated.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run check` passes (0 errors, 1 pre-existing warning)
- [x] `npm run test:unit` passes
- [ ] Manual smoke test on localhost
- [ ] E2E tests in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and production dependencies to their latest versions for improved stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->