### PR TITLE
feat(search): add infinite scroll to search results

### DIFF
--- a/src/lib/components/site/InfiniteScrollSentinel.svelte
+++ b/src/lib/components/site/InfiniteScrollSentinel.svelte
@@ -1,0 +1,63 @@
+<!--
+  @component
+
+  Sentinel component for infinite scrolling.
+  Triggers a callback when it enters the viewport.
+-->
+<script lang="ts">
+    import { onMount } from 'svelte';
+
+    interface Props {
+        onIntersect: () => void;
+        disabled?: boolean;
+        rootMargin?: string;
+    }
+    let { onIntersect, disabled = false, rootMargin = '200px' }: Props = $props();
+
+    let sentinel: HTMLElement;
+    let hasTriggered = $state(false);
+    let isCurrentlyIntersecting = $state(false);
+    let prevDisabled: boolean | undefined = $state(undefined);
+
+    // When disabled changes from true to false while intersecting, trigger again
+    // This handles the case where new results don't push sentinel out of viewport
+    $effect(() => {
+        if (prevDisabled === true && !disabled && isCurrentlyIntersecting) {
+            // Trigger immediately since we're already intersecting and now enabled
+            hasTriggered = true;
+            onIntersect();
+        }
+        prevDisabled = disabled;
+    });
+
+    onMount(() => {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                isCurrentlyIntersecting = entries[0].isIntersecting;
+
+                // Reset trigger flag when sentinel leaves viewport
+                if (!isCurrentlyIntersecting) {
+                    hasTriggered = false;
+                    return;
+                }
+
+                // Only trigger once per intersection, and only if not disabled
+                if (isCurrentlyIntersecting && !disabled && !hasTriggered) {
+                    hasTriggered = true;
+                    onIntersect();
+                }
+            },
+            { rootMargin },
+        );
+        observer.observe(sentinel);
+        return () => observer.disconnect();
+    });
+</script>
+
+<div bind:this={sentinel} class="sentinel"></div>
+
+<style>
+    .sentinel {
+        height: 1px;
+    }
+</style>

--- a/src/lib/models/search.ts
+++ b/src/lib/models/search.ts
@@ -25,6 +25,8 @@ export type SearchResults = {
     /** Total # of results in gallery, not this specific set of results */
     total: number;
     items?: Thumbable[];
+    /** Next offset to use for pagination (based on server response, not filtered items) */
+    nextStartAt?: number;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Replace manual "Get More" button with automatic loading via IntersectionObserver
- Results load automatically as user scrolls near bottom of page
- Add debouncing to prevent rapid-fire requests during fast scrolling
- Filter duplicate items when concatenating paginated results
- Track server offset (nextStartAt) to correctly handle filtered duplicates
- Display total result count in search controls

## Test plan
- [ ] Search for a term with many results (e.g., "felix")
- [ ] Scroll down - verify new results load automatically
- [ ] Verify loading indicator appears while fetching
- [ ] Search with < 30 results - verify no loading indicator appears at bottom
- [ ] Scroll quickly - verify no duplicate requests or images
- [ ] Run `npm run test:unit` and `npm run test:e2e`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Infinite scroll: Search results now load automatically as you scroll down instead of clicking a manual button
  * Result count: Total number of available results is now displayed

* **Bug Fixes**
  * Improved pagination to prevent duplicate results from appearing in searches
  * Added safeguards to prevent excessive server requests during rapid scrolling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->