### PR TITLE
chore: add git workflow skills for branch, commit, and PR conventions

### DIFF
--- a/.claude/skills/branch/SKILL.md
+++ b/.claude/skills/branch/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: branch
+description: Creates git branches with proper naming. Use when creating branches, starting new work, or switching to feature branches.
+---
+
+# Branch Naming
+
+Use `type/short-description` format.
+
+## Types
+
+- `feat`: User-facing features or behavior changes (must change production code)
+- `fix`: Bug fixes (must change production code)
+- `docs`: Documentation only
+- `style`: Code style/formatting (no logic changes)
+- `refactor`: Code restructuring without behavior change
+- `test`: Adding or updating tests
+- `chore`: CI/CD, tooling, dependency bumps, configs (no production code)
+
+## Examples
+
+```text
+feat/infinite-scroll
+fix/album-path-validation
+refactor/state-management
+chore/pre-commit-hooks
+docs/update-readme
+test/e2e-login-flow
+```
+
+## Instructions
+
+1. Determine the type based on what the work will accomplish
+2. Choose a short, descriptive slug (2-4 words, hyphenated)
+3. Create the branch: `git checkout -b type/short-description`

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: commit
+description: Generates commit messages and creates commits. Use when writing commit messages, committing changes, or reviewing staged changes.
+---
+
+# Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format.
+
+## Format
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+```
+
+## Types
+
+- `feat`: User-facing features or behavior changes (must change production code)
+- `fix`: Bug fixes (must change production code)
+- `docs`: Documentation only
+- `style`: Code style/formatting (no logic changes)
+- `refactor`: Code restructuring without behavior change
+- `test`: Adding or updating tests
+- `chore`: CI/CD, tooling, dependency bumps, configs (no production code)
+
+## Scopes
+
+Optional. Use when it adds clarity. Examples: `ui`, `api`, `state`, `auth`.
+
+## Breaking Changes
+
+Use `!` suffix: `feat!: remove deprecated API`
+
+## Examples
+
+```text
+feat(search): add infinite scroll to results
+fix(album): correct image path validation
+refactor(state): simplify album loading machine
+chore: add husky pre-commit hooks
+docs: update API documentation
+test: add E2E tests for login flow
+```
+
+## Instructions
+
+1. Run `git diff --staged` to see staged changes
+2. Analyze the changes and determine the appropriate type
+3. Write a concise description (under 72 characters)
+4. Add body only if the "why" isn't obvious from the description

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pr
+description: Creates pull requests with proper formatting. Use when creating PRs, opening pull requests, or preparing changes for review.
+---
+
+# Pull Requests
+
+## PR Title
+
+Use [Conventional Commit](https://www.conventionalcommits.org/) format, same as commit messages:
+
+```text
+<type>(<scope>): <description>
+```
+
+## Types
+
+- `feat`: User-facing features or behavior changes (must change production code)
+- `fix`: Bug fixes (must change production code)
+- `docs`: Documentation only
+- `style`: Code style/formatting (no logic changes)
+- `refactor`: Code restructuring without behavior change
+- `test`: Adding or updating tests
+- `chore`: CI/CD, tooling, dependency bumps, configs (no production code)
+
+## PR Description Template
+
+```markdown
+## Summary
+
+One sentence describing the overall change.
+
+- Optional supporting details
+- If needed
+
+## Test plan
+
+- [ ] How to verify it works
+```
+
+## Labels
+
+Apply labels using `gh pr create --label <label>` or `gh pr edit --add-label <label>`.
+
+Apply all labels that fit. Only use these labels:
+
+- `enhancement` - User-facing features or improvements (must change production code behavior)
+- `refactor` - Production code changes that don't alter behavior
+- `bug` - Fixes broken production code functionality
+- `test` - Changes to tests
+- `documentation` - Documentation changes
+
+**No label needed** for dependency bumps, CI/CD, tooling, or infrastructure changes - these go in "Other Changes" in release notes.
+
+## Branch Naming
+
+Use `type/short-description`:
+
+```text
+feat/infinite-scroll
+fix/album-path-validation
+chore/pre-commit-hooks
+```
+
+## Instructions
+
+1. Run `git log main..HEAD` to see commits for this branch
+2. Run `git diff main...HEAD` to see all changes
+3. Summarize the changes in 1-2 sentences
+4. Create a test plan with verification steps
+5. Apply appropriate labels

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,18 +133,6 @@ git commit --amend
 git rebase --continue
 ```
 
-## PR Labels
-
-Use labels on pull requests. Apply all labels that fit. Only use the following labels:
-
-- `enhancement` - User-facing features or improvements. Must change production code behavior.
-- `refactor` - Production code changes that don't alter behavior
-- `bug` - Fixes broken production code functionality
-- `test` - Changes to tests
-- `documentation` - Documentation changes
-
-**No label needed** for dependency bumps, CI/CD, tooling, or infrastructure changes - these go in "Other Changes" in release notes.
-
 ## Branch Protection
 
 The `main` branch is protected:
@@ -157,6 +145,81 @@ The `main` branch is protected:
 Repo settings:
 
 - Auto-delete head branches after merge
+
+## Branch, Commit and PR Conventions
+
+Use these types for branch names, commit messages, and PR titles:
+
+- `feat`: User-facing features or behavior changes (must change production code)
+- `fix`: Bug fixes (must change production code)
+- `docs`: Documentation only
+- `style`: Code style/formatting (no logic changes)
+- `refactor`: Code restructuring without behavior change
+- `test`: Adding or updating tests
+- `chore`: CI/CD, tooling, dependency bumps, configs (no production code)
+
+### Branch Naming
+
+Use `type/short-description`:
+
+```text
+feat/infinite-scroll
+fix/album-path-validation
+chore/pre-commit-hooks
+```
+
+### Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+```
+
+- **Scopes:** Optional. Use when it adds clarity (e.g., `ui`, `api`, `state`, `auth`).
+- **Breaking changes:** Use `!` suffix: `feat!: remove deprecated API`
+
+**Examples:**
+
+```text
+feat(search): add infinite scroll to results
+fix(album): correct image path validation
+chore: add husky pre-commit hooks
+docs: update API documentation
+```
+
+### Pull Requests
+
+**PR titles:** Use conventional commit format, same as commit messages.
+
+**PR descriptions:**
+
+```markdown
+## Summary
+
+One sentence describing the overall change.
+
+- Optional supporting details
+- If needed
+
+## Test plan
+
+- [ ] How to verify it works
+```
+
+### PR Labels
+
+Use labels on pull requests. Apply all labels that fit. Only use these labels:
+
+- `enhancement` - User-facing features or improvements (must change production code behavior)
+- `refactor` - Production code changes that don't alter behavior
+- `bug` - Fixes broken production code functionality
+- `test` - Changes to tests
+- `documentation` - Documentation changes
+
+**No label needed** for dependency bumps, CI/CD, tooling, or infrastructure changes - these go in "Other Changes" in release notes.
 
 ## AI Assistant Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,18 +135,6 @@ git commit --amend
 git rebase --continue
 ```
 
-## PR Labels
-
-Use labels on pull requests. Apply all labels that fit. Only use the following labels:
-
-- `enhancement` - User-facing features or improvements. Must change production code behavior.
-- `refactor` - Production code changes that don't alter behavior
-- `bug` - Fixes broken production code functionality
-- `test` - Changes to tests
-- `documentation` - Documentation changes
-
-**No label needed** for dependency bumps, CI/CD, tooling, or infrastructure changes - these go in "Other Changes" in release notes.
-
 ## Branch Protection
 
 The `main` branch is protected:

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -167,18 +167,6 @@ git commit --amend
 git rebase --continue
 ```
 
-## PR Labels
-
-Use labels on pull requests. Apply all labels that fit. Only use the following labels:
-
-- `enhancement` - User-facing features or improvements. Must change production code behavior.
-- `refactor` - Production code changes that don't alter behavior
-- `bug` - Fixes broken production code functionality
-- `test` - Changes to tests
-- `documentation` - Documentation changes
-
-**No label needed** for dependency bumps, CI/CD, tooling, or infrastructure changes - these go in "Other Changes" in release notes.
-
 ## Branch Protection
 
 The `main` branch is protected:
@@ -191,6 +179,85 @@ The `main` branch is protected:
 Repo settings:
 
 - Auto-delete head branches after merge
+
+START_AGENTS
+
+## Branch, Commit and PR Conventions
+
+Use these types for branch names, commit messages, and PR titles:
+
+- `feat`: User-facing features or behavior changes (must change production code)
+- `fix`: Bug fixes (must change production code)
+- `docs`: Documentation only
+- `style`: Code style/formatting (no logic changes)
+- `refactor`: Code restructuring without behavior change
+- `test`: Adding or updating tests
+- `chore`: CI/CD, tooling, dependency bumps, configs (no production code)
+
+### Branch Naming
+
+Use `type/short-description`:
+
+```text
+feat/infinite-scroll
+fix/album-path-validation
+chore/pre-commit-hooks
+```
+
+### Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+```
+
+- **Scopes:** Optional. Use when it adds clarity (e.g., `ui`, `api`, `state`, `auth`).
+- **Breaking changes:** Use `!` suffix: `feat!: remove deprecated API`
+
+**Examples:**
+
+```text
+feat(search): add infinite scroll to results
+fix(album): correct image path validation
+chore: add husky pre-commit hooks
+docs: update API documentation
+```
+
+### Pull Requests
+
+**PR titles:** Use conventional commit format, same as commit messages.
+
+**PR descriptions:**
+
+```markdown
+## Summary
+
+One sentence describing the overall change.
+
+- Optional supporting details
+- If needed
+
+## Test plan
+
+- [ ] How to verify it works
+```
+
+### PR Labels
+
+Use labels on pull requests. Apply all labels that fit. Only use these labels:
+
+- `enhancement` - User-facing features or improvements (must change production code behavior)
+- `refactor` - Production code changes that don't alter behavior
+- `bug` - Fixes broken production code functionality
+- `test` - Changes to tests
+- `documentation` - Documentation changes
+
+**No label needed** for dependency bumps, CI/CD, tooling, or infrastructure changes - these go in "Other Changes" in release notes.
+
+END_AGENTS
 
 ## AI Assistant Configuration
 


### PR DESCRIPTION
## Summary

Add Claude Code skills for git workflow conventions (branch naming, commit messages, PR formatting) to enable on-demand loading instead of embedding in CLAUDE.md.

- Created `.claude/skills/branch/SKILL.md` - branch naming conventions
- Created `.claude/skills/commit/SKILL.md` - conventional commit format
- Created `.claude/skills/pr/SKILL.md` - PR title, description, and label conventions
- Non-Claude agents still receive conventions via `AGENTS.md` using conditional markers

## Test plan

- [ ] Verify skills load when invoked (e.g., `/commit`, `/branch`, `/pr`)
- [ ] Verify CLAUDE.md no longer contains PR Labels section
- [ ] Verify AGENTS.md still contains full branch/commit/PR conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Established standardized conventions for branch naming, commit messages, and pull request workflows aligned with Conventional Commits format.
  * Created comprehensive development workflow guides to streamline collaboration and code review processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->