### PR TITLE
chore: remove breaking changes section from commit skill

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -29,10 +29,6 @@ Use [Conventional Commits](https://www.conventionalcommits.org/) format.
 
 Optional. Use when it adds clarity. Examples: `ui`, `api`, `state`, `auth`.
 
-## Breaking Changes
-
-Use `!` suffix: `feat!: remove deprecated API`
-
 ## Examples
 
 ```text


### PR DESCRIPTION
## Summary
- Removed the "Breaking Changes" section from the commit skill documentation
- The backtick pattern `` `!` suffix: `feat!: `` was being incorrectly parsed by Claude Code's permission checker as a bash command, blocking the skill from executing

## Test plan
- [x] Verify the commit skill can now be invoked without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)