### PR TITLE
fix: prevent dialog from disappearing when mouse leaves viewport

### DIFF
--- a/src/lib/actions/portal.ts
+++ b/src/lib/actions/portal.ts
@@ -1,0 +1,15 @@
+/**
+ * Svelte action that moves an element to be a direct child of <body>.
+ * Useful for dialogs/modals that need to escape parent CSS like display:none.
+ */
+export function portal(node: HTMLElement) {
+    // Move this element from where it is in the DOM to be a child of <body>
+    document.body.appendChild(node);
+
+    return {
+        destroy() {
+            // When the Svelte component is destroyed, clean up the DOM node
+            node.remove();
+        },
+    };
+}

--- a/src/lib/components/site/admin/Dialog.svelte
+++ b/src/lib/components/site/admin/Dialog.svelte
@@ -5,6 +5,7 @@
 -->
 <script lang="ts">
     import type { Snippet } from 'svelte';
+    import { portal } from '$lib/actions/portal';
 
     interface Props {
         content?: Snippet;
@@ -37,16 +38,18 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<dialog bind:this={dialog} onclick={onClick}>
-    <form method="dialog" {onkeydown}>
-        <p>
-            {@render content?.()}
-        </p>
-        <menu>
-            {@render buttons?.()}
-        </menu>
-    </form>
-</dialog>
+<div use:portal>
+    <dialog bind:this={dialog} onclick={onClick}>
+        <form method="dialog" {onkeydown}>
+            <p>
+                {@render content?.()}
+            </p>
+            <menu>
+                {@render buttons?.()}
+            </menu>
+        </form>
+    </dialog>
+</div>
 
 <style>
     dialog::backdrop {


### PR DESCRIPTION
The New Album dialog was disappearing IMMEDIATELY when the mouse leaves the viewport.  This fixes.

## Summary
- Dialog was rendered inside a nav element controlled by CSS `:hover`
- When mouse left viewport, nav got `display:none`, hiding the dialog
- Added a portal action that moves the dialog to `<body>` where it's immune to parent CSS

Fixes #58

## Test plan
- [ ] Open the New Album dialog
- [ ] Move mouse to browser URL bar (outside viewport)
- [ ] Verify dialog stays visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dialog and modal positioning to properly escape CSS constraints from parent containers, ensuring improved visibility and rendering in complex page layouts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->