### PR TITLE
feat: support HEIC/HEIF image upload

### DIFF
--- a/src/lib/components/pages/album/day/DayAlbumFullScreenDropZone.svelte
+++ b/src/lib/components/pages/album/day/DayAlbumFullScreenDropZone.svelte
@@ -11,6 +11,7 @@
     import type { ImageToUpload } from '$lib/models/album';
     import { sessionStore } from '$lib/stores/SessionStore.svelte';
     import { albumState } from '$lib/stores/AlbumState.svelte';
+    import { getConvertedJpgPath } from '$lib/utils/uploadUtils';
 
     interface Props {
         albumPath: string;
@@ -45,7 +46,15 @@
         const albumEntry = albumState.albums.get(albumPath);
         if (!albumEntry || !albumEntry.album || !albumEntry.album?.images?.length) return imageNames;
         for (const file of files) {
-            const image = albumEntry.album?.getImage(file.imagePath);
+            // Check if exact path exists
+            let image = albumEntry.album?.getImage(file.imagePath);
+            // For HEIC/HEIF, also check if the converted JPG exists (backend converts HEIC→JPG)
+            if (!image) {
+                const convertedPath = getConvertedJpgPath(file.imagePath);
+                if (convertedPath) {
+                    image = albumEntry.album?.getImage(convertedPath);
+                }
+            }
             if (image) {
                 console.log(`File [${file.imagePath}] is already in album [${albumPath}]`);
                 imageNames.push(file.file.name);

--- a/src/lib/components/site/Thumbnail.svelte
+++ b/src/lib/components/site/Thumbnail.svelte
@@ -40,7 +40,9 @@
 
 <div class="thumbnail">
     <a {href}
-        ><img {src} alt={title} />{#if creating}<div class="icon-overlay">
+        >{#if src}<img {src} alt={title} />{:else}<div class="no-image"></div>{/if}{#if creating}<div
+                class="icon-overlay"
+            >
                 <CreateIcon width="10em" height="10em" />
             </div>{:else if deleting}<div class="icon-overlay">
                 <DeleteIcon width="10em" height="10em" />
@@ -81,10 +83,15 @@
         margin-top: 0.3em;
     }
 
-    img {
+    img,
+    .no-image {
         width: var(--thumbnail-width);
         height: var(--thumbnail-height);
         border: var(--default-border);
+    }
+
+    .no-image {
+        background-color: #f0f0f0;
     }
 
     .icon-overlay {

--- a/src/lib/stores/admin/UploadMachine.svelte.ts
+++ b/src/lib/stores/admin/UploadMachine.svelte.ts
@@ -189,13 +189,16 @@ class UploadMachine {
      * Poll the server, checking to see if the images have made it into the album
      */
     async #pollForProcessedImages(albumPath: string): Promise<void> {
+        const POLL_INTERVAL_MS = 1500;
+        const MAX_POLL_ATTEMPTS = 10;
+
         let processingComplete = false;
         let pollAttemptCount = 0;
         do {
-            await sleep(1500);
+            await sleep(POLL_INTERVAL_MS);
             processingComplete = await this.#areImagesProcessed(albumPath);
             pollAttemptCount++;
-        } while (!processingComplete && pollAttemptCount <= 5);
+        } while (!processingComplete && pollAttemptCount < MAX_POLL_ATTEMPTS);
         console.log(`Images have been processed.  Loop count: [${pollAttemptCount}]`);
 
         // If polling timed out with images still processing, clear them from UI and notify user

--- a/src/lib/utils/galleryPathUtils.spec.ts
+++ b/src/lib/utils/galleryPathUtils.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, describe } from 'vitest';
-import { sanitizeImageName, deduplicateImagePaths } from './galleryPathUtils';
+import {
+    sanitizeImageName,
+    deduplicateImagePaths,
+    hasValidExtension,
+    isValidImagePath,
+    validFileExtensions,
+} from './galleryPathUtils';
 
 describe('sanitizeImageName', () => {
     // Basic transformations
@@ -81,6 +87,61 @@ describe('sanitizeImageName', () => {
         expect(sanitizeImageName('Screenshot 2024-01-15 at 10.30.45 AM.png')).toBe(
             'screenshot_2024_01_15_at_10.30.45_am.png',
         );
+    });
+});
+
+describe('hasValidExtension', () => {
+    test('accepts standard image extensions', () => {
+        expect(hasValidExtension('photo.jpg')).toBe(true);
+        expect(hasValidExtension('photo.jpeg')).toBe(true);
+        expect(hasValidExtension('photo.png')).toBe(true);
+        expect(hasValidExtension('photo.gif')).toBe(true);
+    });
+
+    test('accepts HEIC/HEIF extensions', () => {
+        expect(hasValidExtension('photo.heic')).toBe(true);
+        expect(hasValidExtension('photo.heif')).toBe(true);
+        expect(hasValidExtension('photo.HEIC')).toBe(true);
+        expect(hasValidExtension('photo.HEIF')).toBe(true);
+    });
+
+    test('is case insensitive', () => {
+        expect(hasValidExtension('photo.JPG')).toBe(true);
+        expect(hasValidExtension('photo.PNG')).toBe(true);
+        expect(hasValidExtension('photo.Heic')).toBe(true);
+    });
+
+    test('rejects invalid extensions', () => {
+        expect(hasValidExtension('photo.txt')).toBe(false);
+        expect(hasValidExtension('photo.pdf')).toBe(false);
+        expect(hasValidExtension('photo.webp')).toBe(false);
+    });
+
+    test('rejects extension-only filenames', () => {
+        expect(hasValidExtension('.jpg')).toBe(false);
+        expect(hasValidExtension('.png')).toBe(false);
+        expect(hasValidExtension('.heic')).toBe(false);
+    });
+});
+
+describe('isValidImagePath', () => {
+    test('accepts HEIC/HEIF image paths', () => {
+        expect(isValidImagePath('/2024/01-15/photo.heic')).toBe(true);
+        expect(isValidImagePath('/2024/01-15/photo.heif')).toBe(true);
+        expect(isValidImagePath('/2024/01-15/photo.HEIC')).toBe(true);
+    });
+
+    test('accepts standard image paths', () => {
+        expect(isValidImagePath('/2024/01-15/photo.jpg')).toBe(true);
+        expect(isValidImagePath('/2024/01-15/photo.png')).toBe(true);
+    });
+});
+
+describe('validFileExtensions', () => {
+    test('includes heic and heif', () => {
+        const extensions = validFileExtensions();
+        expect(extensions).toContain('heic');
+        expect(extensions).toContain('heif');
     });
 });
 

--- a/src/lib/utils/galleryPathUtils.ts
+++ b/src/lib/utils/galleryPathUtils.ts
@@ -46,7 +46,9 @@ export function isValidDayAlbumName(dayAlbumName: string): boolean {
  * Must be on a day album like /2001/12-31/image.jpg
  */
 export function isValidImagePath(imagePath: string): boolean {
-    return /^\/\d\d\d\d\/(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\/[a-zA-Z0-9_-]+\.(jpg|jpeg|gif|png)$/i.test(imagePath);
+    return /^\/\d\d\d\d\/(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\/[a-zA-Z0-9_-]+\.(jpg|jpeg|png|gif|heic|heif)$/i.test(
+        imagePath,
+    );
 }
 
 /**
@@ -239,12 +241,12 @@ export function deduplicateImagePaths(imagePaths: string[]): string[] {
 
 /** Return true if specified filename ends with a supported extension */
 export function hasValidExtension(fileName: string): boolean {
-    return /\.(jpg|jpeg|gif|png)$/i.test(fileName);
+    return /^.+\.(jpg|jpeg|png|gif|heic|heif)$/i.test(fileName);
 }
 
 /** Supported file extensions */
 export function validFileExtensions(): string[] {
-    return ['jpg', 'jpeg', 'png', 'gif'];
+    return ['jpg', 'jpeg', 'png', 'gif', 'heic', 'heif'];
 }
 
 /** Return something like ".jpg, .jpeg, .png, .gif" */

--- a/src/lib/utils/imageValidation.spec.ts
+++ b/src/lib/utils/imageValidation.spec.ts
@@ -78,4 +78,31 @@ describe('validateImageBatch', () => {
         expect(result.valid).toHaveLength(0);
         expect(result.invalid).toHaveLength(0);
     });
+
+    it('accepts HEIC files without content validation (skips Image load)', async () => {
+        const files = [createImageToUpload('photo.heic', 100)];
+
+        const result = await validateImageBatch(files);
+
+        expect(result.valid).toHaveLength(1);
+        expect(result.invalid).toHaveLength(0);
+    });
+
+    it('accepts HEIF files without content validation', async () => {
+        const files = [createImageToUpload('photo.heif', 100)];
+
+        const result = await validateImageBatch(files);
+
+        expect(result.valid).toHaveLength(1);
+        expect(result.invalid).toHaveLength(0);
+    });
+
+    it('still rejects zero-byte HEIC files', async () => {
+        const files = [createImageToUpload('empty.heic', 0)];
+
+        const result = await validateImageBatch(files);
+
+        expect(result.valid).toHaveLength(0);
+        expect(result.invalid).toEqual(['/2024/01-01/empty.heic']);
+    });
 });


### PR DESCRIPTION
## Summary
- Add HEIC/HEIF to valid file extensions for image uploads
- Skip browser Image validation for HEIC files (most browsers can't load them, backend handles conversion)
- Add `createPreviewUrl()` to test if browser can display HEIC thumbnails (Safari can, others get placeholder)
- Handle HEIC→JPG backend conversion in upload completion detection (check JPG existence, not versionId match)
- Warn when uploading `foo.heic` if `foo.jpg` already exists in album (would overwrite after conversion)
- Double poll attempts from 5 to 10 for slower HEIC processing time

The back end implementation is in this PR: https://github.com/deanmoses/tacocat-gallery-sam/pull/99

Together, these two PRs close https://github.com/deanmoses/tacocat-gallery-sam/issues/19

## Test plan
- [x] Unit tests pass (72 tests including new HEIC-specific tests)
- [x] Type checking passes
- [x] Linting passes
- [ ] Manual test: Upload HEIC files and verify they appear after backend processing
- [ ] Manual test: Safari shows HEIC thumbnails during upload; other browsers show placeholder
- [ ] Manual test: Uploading `foo.heic` when `foo.jpg` exists shows overwrite warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full support for HEIC/HEIF image formats
  * Placeholder displays for missing images instead of broken states

* **Improvements**
  * Enhanced detection of previously uploaded HEIC images through automatic format conversion matching
  * Extended processing timeout to improve upload reliability and completion detection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->