### PR TITLE
fix(auth): prevent flash of incorrect auth state on login page

### DIFF
--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -6,10 +6,13 @@
     import { sessionStore } from '$lib/stores/SessionStore.svelte';
 
     let isAdmin = $derived(sessionStore.isAdmin);
+    let isCheckingAuth = $derived(sessionStore.isCheckingAuth);
 </script>
 
-<BlankSearchPageLayout searchTerms="" returnPath="/" title={isAdmin ? 'Logout' : 'Login'}>
-    {#if isAdmin}
+<BlankSearchPageLayout searchTerms="" returnPath="/" title={isCheckingAuth ? '' : isAdmin ? 'Logout' : 'Login'}>
+    {#if isCheckingAuth}
+        <p>Checking authentication...</p>
+    {:else if isAdmin}
         <p>You're logged in</p>
         <p><a href={getLogoutUrl()}><LogoutIcon width="1.4em" height="1.3em" /> Logout</a></p>
     {:else}


### PR DESCRIPTION
The login page was briefly showing a 'login' link to logged-in people, while it did its auth check.  Instead, now it shows "Checking authentication...".

## Summary
- Add `isCheckingAuth` state to SessionStore to track when auth check is in progress
- Login page shows "Checking authentication..." instead of flashing the login button when user is already authenticated

## Test plan
- [ ] Visit `/login` while authenticated - should briefly show "Checking authentication..." then "You're logged in"
- [ ] Visit `/login` while not authenticated - should briefly show "Checking authentication..." then login link
- [ ] Verify no flash of incorrect UI state

🤖 Generated with [Claude Code](https://claude.ai/code)