### PR TITLE
feat(auth): automatically refresh expired auth cookies during admin tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ test-results/
 # temporary editor save files
 *~
 
-# OSX thumnail caches
+# OSX thumbnail caches
 .DS_Store
 
 # log files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,19 +12,23 @@ This file provides guidance to AI programming agents when working with code in t
 npm run dev          # Start Vite dev server
 npm run build        # Production build
 npm run build-debug  # Build with sourcemaps, no minification
-npm run preview      # Preview built app
-npm run test         # Run all tests (unit + E2E)
 npm run test:unit    # Run Vitest unit tests
 npm run test:e2e     # Run Playwright E2E tests
+npm run test         # Run all tests (unit + E2E)
 npm run check        # Type checking (svelte-check + TypeScript)
 npm run lint         # ESLint + Prettier check
 npm run format       # Auto-format with Prettier
 npm run quality      # Format, lint, and type check
 npm run precommit    # Quality checks + unit tests (for pre-commit/pre-PR)
 npm run agent-docs   # Regenerate CLAUDE.md and AGENTS.md
-npm run deploy-staging  # Deploy to staging (S3 + CloudFront)
-npm run deploy-prod     # Deploy to production
+npm run build && npm run deploy-staging  # Build and deploy to staging
 ```
+
+Do NOT deploy to production. NEVER deploy to production. There's a GitHub Action for that, that runs integration tests and creates a release tag and a release.
+
+Merging to `main` automatically deploys to staging via GitHub Actions.
+
+## Node.js
 
 Requires Node.js >=24.0.0.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,19 +12,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 npm run dev          # Start Vite dev server
 npm run build        # Production build
 npm run build-debug  # Build with sourcemaps, no minification
-npm run preview      # Preview built app
-npm run test         # Run all tests (unit + E2E)
 npm run test:unit    # Run Vitest unit tests
 npm run test:e2e     # Run Playwright E2E tests
+npm run test         # Run all tests (unit + E2E)
 npm run check        # Type checking (svelte-check + TypeScript)
 npm run lint         # ESLint + Prettier check
 npm run format       # Auto-format with Prettier
 npm run quality      # Format, lint, and type check
 npm run precommit    # Quality checks + unit tests (for pre-commit/pre-PR)
 npm run agent-docs   # Regenerate CLAUDE.md and AGENTS.md
-npm run deploy-staging  # Deploy to staging (S3 + CloudFront)
-npm run deploy-prod     # Deploy to production
+npm run build && npm run deploy-staging  # Build and deploy to staging
 ```
+
+Do NOT deploy to production. NEVER deploy to production. There's a GitHub Action for that, that runs integration tests and creates a release tag and a release.
+
+Merging to `main` automatically deploys to staging via GitHub Actions.
+
+## Node.js
 
 Requires Node.js >=24.0.0.
 

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -33,19 +33,23 @@ END_AGENTS
 npm run dev          # Start Vite dev server
 npm run build        # Production build
 npm run build-debug  # Build with sourcemaps, no minification
-npm run preview      # Preview built app
-npm run test         # Run all tests (unit + E2E)
 npm run test:unit    # Run Vitest unit tests
 npm run test:e2e     # Run Playwright E2E tests
+npm run test         # Run all tests (unit + E2E)
 npm run check        # Type checking (svelte-check + TypeScript)
 npm run lint         # ESLint + Prettier check
 npm run format       # Auto-format with Prettier
 npm run quality      # Format, lint, and type check
 npm run precommit    # Quality checks + unit tests (for pre-commit/pre-PR)
 npm run agent-docs   # Regenerate CLAUDE.md and AGENTS.md
-npm run deploy-staging  # Deploy to staging (S3 + CloudFront)
-npm run deploy-prod     # Deploy to production
+npm run build && npm run deploy-staging  # Build and deploy to staging
 ```
+
+Do NOT deploy to production. NEVER deploy to production. There's a GitHub Action for that, that runs integration tests and creates a release tag and a release.
+
+Merging to `main` automatically deploys to staging via GitHub Actions.
+
+## Node.js
 
 Requires Node.js >=24.0.0.
 

--- a/src/lib/stores/admin/AlbumCreateMachine.svelte.ts
+++ b/src/lib/stores/admin/AlbumCreateMachine.svelte.ts
@@ -1,6 +1,7 @@
 import { toast } from '@zerodevx/svelte-toast';
 import { getParentFromPath, isValidAlbumPath } from '$lib/utils/galleryPathUtils';
 import { createUrl } from '$lib/utils/config';
+import { adminApi } from '$lib/utils/adminApi';
 import { albumState } from '../AlbumState.svelte';
 import { CreateStatus } from '$lib/models/album';
 import { albumLoadMachine } from '../AlbumLoadMachine.svelte';
@@ -62,18 +63,10 @@ class AlbumCreateMachine {
         try {
             if (!isValidAlbumPath(albumPath)) throw new Error(`Invalid album path [${albumPath}]`);
             this.#createStarted(albumPath);
-            const response = await fetch(createUrl(albumPath), {
-                method: 'PUT',
-                credentials: 'include',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({}),
-            });
+            const response = await adminApi.put(createUrl(albumPath));
             if (!response.ok) {
-                const msg = (await response.json()).errorMessage || response.statusText;
-                throw new Error(msg);
+                const json = await response.json().catch(() => ({}));
+                throw new Error(json?.errorMessage || response.statusText);
             }
             await albumLoadMachine.fetchFromServer(albumPath); // load newly created album
             this.#success(albumPath);

--- a/src/lib/stores/admin/AlbumRenameMachine.svelte.ts
+++ b/src/lib/stores/admin/AlbumRenameMachine.svelte.ts
@@ -1,5 +1,6 @@
 import { RenameStatus } from '$lib/models/album';
 import { renameAlbumUrl } from '$lib/utils/config';
+import { adminApi } from '$lib/utils/adminApi';
 import { getNameFromPath, getParentFromPath, isValidDayAlbumPath } from '$lib/utils/galleryPathUtils';
 import { toast } from '@zerodevx/svelte-toast';
 import { albumLoadMachine } from '../AlbumLoadMachine.svelte';
@@ -67,18 +68,10 @@ class AlbumRenameMachine {
             const newName = getNameFromPath(newAlbumPath);
             console.log(`Renaming album [${oldAlbumPath}] to [${newName}]...`);
             this.#renameStarted(oldAlbumPath, newAlbumPath);
-            const response = await fetch(renameAlbumUrl(oldAlbumPath), {
-                method: 'POST',
-                credentials: 'include',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ newName }),
-            });
+            const response = await adminApi.post(renameAlbumUrl(oldAlbumPath), { newName });
             if (!response.ok) {
-                const msg = (await response.json()).errorMessage || response.statusText;
-                throw msg;
+                const json = await response.json().catch(() => ({}));
+                throw new Error(json?.errorMessage || response.statusText);
             }
             // Fetch parent album to get renamed album added to it
             // Do NOT async await because we want the UI to move to

--- a/src/lib/stores/admin/AlbumThumbnailSetMachine.svelte.ts
+++ b/src/lib/stores/admin/AlbumThumbnailSetMachine.svelte.ts
@@ -2,6 +2,7 @@ import { SvelteMap } from 'svelte/reactivity';
 import { albumLoadMachine } from '../AlbumLoadMachine.svelte';
 import { ReloadStatus } from '$lib/models/album';
 import { setThumbnailUrl } from '$lib/utils/config';
+import { adminApi } from '$lib/utils/adminApi';
 import { toast } from '@zerodevx/svelte-toast';
 import { getParentFromPath, isValidYearAlbumPath } from '$lib/utils/galleryPathUtils';
 
@@ -75,7 +76,7 @@ class AlbumThumbnailSetMachine {
 
         if (isValidYearAlbumPath(albumPath)) {
             const year = albumPath.replaceAll('/', '');
-            toast.push(`Thumnbnail set for ${year}`);
+            toast.push(`Thumbnail set for ${year}`);
         }
     }
 
@@ -100,18 +101,12 @@ class AlbumThumbnailSetMachine {
     async #setAlbumThumbnail(albumPath: string, newThumbnailImagePath: string): Promise<void> {
         console.log(`Setting thumbnail of album [${albumPath}] to [${newThumbnailImagePath}]`);
         try {
-            const response = await fetch(setThumbnailUrl(albumPath), {
-                method: 'PATCH',
-                credentials: 'include',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ imagePath: newThumbnailImagePath }),
+            const response = await adminApi.patch(setThumbnailUrl(albumPath), {
+                imagePath: newThumbnailImagePath,
             });
             if (!response.ok) {
-                const msg = (await response.json()).errorMessage || response.statusText;
-                throw new Error(msg);
+                const json = await response.json().catch(() => ({}));
+                throw new Error(json?.errorMessage || response.statusText);
             }
             console.log(`Set thumbnail of album [${albumPath}] to [${newThumbnailImagePath}]`);
             console.log(`Reloading album [${albumPath}] from server`);

--- a/src/lib/stores/admin/CropMachine.svelte.ts
+++ b/src/lib/stores/admin/CropMachine.svelte.ts
@@ -1,5 +1,6 @@
 import { albumLoadMachine } from '../AlbumLoadMachine.svelte';
 import { recropThumbnailUrl } from '$lib/utils/config';
+import { adminApi } from '$lib/utils/adminApi';
 import { toast } from '@zerodevx/svelte-toast';
 import { getParentFromPath } from '$lib/utils/galleryPathUtils';
 import { albumState } from '../AlbumState.svelte';
@@ -64,20 +65,12 @@ class CropMachine {
     async #crop(imagePath: string, crop: Crop): Promise<void> {
         try {
             // Make the save request
-            const response = await fetch(recropThumbnailUrl(imagePath), {
-                method: 'PATCH',
-                credentials: 'include',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(crop),
-            });
+            const response = await adminApi.patch(recropThumbnailUrl(imagePath), crop);
 
             // Check for errors
             if (!response.ok) {
-                const msg = (await response.json()).errorMessage || response.statusText;
-                throw new Error(msg);
+                const json = await response.json().catch(() => ({}));
+                throw new Error(json?.errorMessage || response.statusText);
             }
 
             console.log(`Updated thumbnail of [${imagePath}]`);

--- a/src/lib/stores/admin/ImageDeleteMachine.svelte.ts
+++ b/src/lib/stores/admin/ImageDeleteMachine.svelte.ts
@@ -1,5 +1,6 @@
 import { DeleteStatus } from '$lib/models/album';
 import { deleteUrl } from '$lib/utils/config';
+import { adminApi } from '$lib/utils/adminApi';
 import { getParentFromPath, isValidImagePath } from '$lib/utils/galleryPathUtils';
 import { toast } from '@zerodevx/svelte-toast';
 import { albumState } from '../AlbumState.svelte';
@@ -59,17 +60,10 @@ class ImageDeleteMachine {
         try {
             if (!isValidImagePath(imagePath)) throw new Error(`Invalid image path [${imagePath}]`);
             this.#deleteStarted(imagePath);
-            const response = await fetch(deleteUrl(imagePath), {
-                method: 'DELETE',
-                credentials: 'include',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                },
-            });
+            const response = await adminApi.delete(deleteUrl(imagePath));
             if (!response.ok) {
-                const msg = (await response.json()).errorMessage || response.statusText;
-                throw new Error(msg);
+                const json = await response.json().catch(() => ({}));
+                throw new Error(json?.errorMessage || response.statusText);
             }
             console.log(`Image [${imagePath}] deleted`);
             // reload the album

--- a/src/lib/utils/adminApi.ts
+++ b/src/lib/utils/adminApi.ts
@@ -1,0 +1,89 @@
+/**
+ * Authenticated API client for admin operations.
+ *
+ * Provides a simple interface for making authenticated requests to the gallery API.
+ * Automatically handles 401 responses by refreshing the auth token and retrying once.
+ */
+
+import { checkAuthenticationUrl } from './config';
+import { sessionStore } from '$lib/stores/SessionStore.svelte';
+
+/**
+ * Low-level fetch wrapper that handles 401 by refreshing the token and retrying once.
+ */
+async function authFetch(url: string, init: RequestInit): Promise<Response> {
+    const response = await fetch(url, { ...init, credentials: 'include' });
+
+    if (response.status !== 401) {
+        return response;
+    }
+
+    // Try to refresh the token via auth service
+    const refreshResponse = await fetch(checkAuthenticationUrl(), {
+        cache: 'no-store',
+        credentials: 'include',
+    });
+
+    if (!refreshResponse.ok) {
+        // Refresh failed - user session is truly expired
+        sessionStore.fetchUserStatus(); // Updates UI to show logged-out state
+        throw new Error('Your session has expired. Please log in again.');
+    }
+
+    // Token refreshed - retry the original request
+    return fetch(url, { ...init, credentials: 'include' });
+}
+
+const JSON_HEADERS = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+};
+
+/**
+ * Authenticated API client for admin operations.
+ * Includes automatic token refresh on 401, credentials, and JSON headers.
+ */
+export const adminApi = {
+    async get(url: string): Promise<Response> {
+        return authFetch(url, {
+            method: 'GET',
+            credentials: 'include',
+            headers: JSON_HEADERS,
+        });
+    },
+
+    async post(url: string, body: object): Promise<Response> {
+        return authFetch(url, {
+            method: 'POST',
+            credentials: 'include',
+            headers: JSON_HEADERS,
+            body: JSON.stringify(body),
+        });
+    },
+
+    async put(url: string, body: object = {}): Promise<Response> {
+        return authFetch(url, {
+            method: 'PUT',
+            credentials: 'include',
+            headers: JSON_HEADERS,
+            body: JSON.stringify(body),
+        });
+    },
+
+    async patch(url: string, body: object): Promise<Response> {
+        return authFetch(url, {
+            method: 'PATCH',
+            credentials: 'include',
+            headers: JSON_HEADERS,
+            body: JSON.stringify(body),
+        });
+    },
+
+    async delete(url: string): Promise<Response> {
+        return authFetch(url, {
+            method: 'DELETE',
+            credentials: 'include',
+            headers: JSON_HEADERS,
+        });
+    },
+};

--- a/src/lib/utils/s3Upload.ts
+++ b/src/lib/utils/s3Upload.ts
@@ -1,4 +1,5 @@
 import { getPresignedUploadUrlGenerationUrl } from './config';
+import { adminApi } from './adminApi';
 
 export type S3UploadResult = { success: true; versionId: string } | { success: false; error: string };
 
@@ -49,15 +50,7 @@ export async function uploadToS3(file: File, presignedUrl: string): Promise<S3Up
  */
 export async function fetchPresignedUrls(albumPath: string, imagePaths: string[]): Promise<PresignedUrlResult> {
     try {
-        const response = await fetch(getPresignedUploadUrlGenerationUrl(albumPath), {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-                Accept: 'application/json',
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(imagePaths),
-        });
+        const response = await adminApi.post(getPresignedUploadUrlGenerationUrl(albumPath), imagePaths);
 
         if (!response.ok) {
             const body = await response.json().catch(() => ({}));

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -35,13 +35,13 @@
 </script>
 
 {@render children?.()}
-{#if sessionStore.isAdmin}
-    <!-- 
-		Lazy / async / dynamic load this component.
-		It's a hint to the bundling system that this code 
-        can be put into a separate bundle, so that non-admins
-		aren't forced to load it.
-	-->
+{#if sessionStore.isAdmin || sessionStore.hasBeenLoggedIn}
+    <!--
+        Toast component for admin notifications.
+        Uses hasBeenLoggedIn so toasts remain visible even after logout
+        (e.g., "session expired" errors). Lazy loaded so users who have
+        never logged in don't pay the bundle cost.
+    -->
     {#await import('@zerodevx/svelte-toast') then { SvelteToast }}
         <SvelteToast />
     {/await}


### PR DESCRIPTION
## Summary

The AWS back end of the Tacocat photo gallery system recently fixed some authentication bugs: https://github.com/deanmoses/tacocat-gallery-sam/issues/30 , and is now refusing more operations because the user's auth cookies expire.

These are the front end changes to deal with that.  When an admin's `id_token` cookie expires mid-session (after 1 hour), admin operations would fail.  Now, the client detects 401 Unauthorized responses from the back end API and attempts to refresh the `id_token` auth cookie via the auth service, and retries the original request.  This saves the user the hassle of the operation failing and having to click around to get re-logged in again.

To implement this, we added an `adminApi` helper that wraps fetch calls for admin operations. When a request returns 401, it attempts to refresh the `id_token` auth cookie and retries the request. If refresh fails, most areas in the UI show a toast.

Additionally, the toast wasn't displaying for 'unauthorized' messages because the toast component was only being loaded for admins, and the user was logged out, so the toast component was removed from the page.  We fixed this by leaving the toast in the page if the user had EVER been logged in.  It's still not loaded for people who have never been logged in, to prevent them from downloading unnecessary code.

## Changes

- Add `adminApi` helper that wraps HTTP fetch calls with automatic 401 → refresh → retry logic
- Update all admin state machines to use adminApi instead of raw fetch
- Keep toast component mounted for users who have ever logged in so
  session-expired errors display even after logout
- Fix JSON parse error handling with .catch() fallback across all
  admin machines
 
## Test plan

- [x] Delete only `id_token` cookie, perform admin operation → succeeds silently, cookie restored
- [x] Delete both cookies, perform admin operation → toast shows "session expired" message

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected "Thumbnail" text display spelling
  * Toast notifications now persist after logout for previously logged-in users

* **Documentation**
  * Updated Node.js requirement to >=24.0.0
  * Clarified deployment workflow: staging deploys via GitHub Actions upon main merge; production deployment handled automatically without manual intervention

* **Chores**
  * Fixed comment typo in configuration files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->