### PR TITLE
fix: prevent layout shift when detail image loads

### DIFF
--- a/src/lib/components/pages/image/BigImage.svelte
+++ b/src/lib/components/pages/image/BigImage.svelte
@@ -19,11 +19,15 @@
 	Wrapping the image in a #key block seems to make this problem go away.
 -->
 {#key image.path}
-    <a href={image.originalUrl}>
+    <a href={image.originalUrl} aria-label="View full-size image: {image.title}">
         <img
             src={image.detailUrl}
-            style="max-width: {image.detailWidth}px; max-height: {image.detailHeight}px;"
+            style="max-width: {image.detailWidth}px; max-height: {image.detailHeight}px; aspect-ratio: {image.detailWidth} / {image.detailHeight};"
             alt={image.title}
+            loading="eager"
+            decoding="async"
+            fetchpriority="high"
+            draggable="false"
         />
     </a>
 {/key}
@@ -33,5 +37,7 @@
         object-fit: contain;
         width: 100%;
         height: 100%;
+        color: transparent; /* Hide alt text while image loads */
+        background-color: #f0f0f0;
     }
 </style>


### PR DESCRIPTION
## Summary

On the photo detail page, the layout was shifting when the photo loaded. This PR fixes it by:

- Adding `aspect-ratio` CSS to reserve correct space before image loads
- Adding gray placeholder background while image loads  
- Hiding alt text visually with `color: transparent` to prevent text flash

**Note:** EXIF-rotated images may still shift due to backend returning raw pixel dimensions instead of display dimensions (see deanmoses/tacocat-gallery-sam#105)

## Other changes

Accessibility and performance improvements:
- Add `aria-label` to link describing its purpose ("View full-size image")
- Add `loading="eager"`, `decoding="async"`, `fetchpriority="high"` for performance
- Add `draggable="false"` to prevent drag interference

## Test plan

- [ ] Navigate to a photo detail page and verify no layout shift when image loads
- [ ] Verify gray placeholder appears briefly before image loads (throttle network to see it)
- [ ] Verify portrait and landscape images display correctly

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Accessibility**
  * Images now load faster with optimized rendering and fetching behavior
  * Enhanced accessibility with descriptive labels providing better support for screen readers
  * Improved visual appearance during image loading with proper aspect ratio display

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->