### PR TITLE
perf: preload adjacent images for smoother navigation

### DIFF
--- a/src/lib/components/pages/image/ImagePage.svelte
+++ b/src/lib/components/pages/image/ImagePage.svelte
@@ -19,7 +19,20 @@
     }
     let { album, image }: Props = $props();
     let imageTitle = $derived(image.title);
+
+    // Preload adjacent images for smoother navigation
+    let nextImage = $derived(image.nextHref ? album.getImage(image.nextHref) : undefined);
+    let prevImage = $derived(image.prevHref ? album.getImage(image.prevHref) : undefined);
 </script>
+
+<svelte:head>
+    {#if nextImage}
+        <link rel="preload" as="image" href={nextImage.detailUrl} />
+    {/if}
+    {#if prevImage}
+        <link rel="preload" as="image" href={prevImage.detailUrl} />
+    {/if}
+</svelte:head>
 
 <ImagePageLayout title={imageTitle}>
     {#snippet editControls()}


### PR DESCRIPTION
## Summary

When viewing an image, preload the next and previous images using `<link rel="preload">` so they're already cached when the user navigates. This eliminates the gray placeholder flash when clicking through an album.

## Implementation

- Use `$derived` to get the next/prev `Image` objects from the album
- Add `<svelte:head>` with preload links for their `detailUrl`s
- Svelte handles cleanup automatically when navigating away

## Test plan

- [ ] Navigate to an image detail page
- [ ] Click next/prev rapidly - images should appear instantly without gray placeholder
- [ ] Check Network tab - next/prev images should be fetched in background

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image preloading: The application now automatically preloads the next and previous images in the background while you view the current image. This intelligent preloading eliminates loading delays during navigation, providing a noticeably smoother and faster browsing experience. Navigate seamlessly through image galleries and collections with improved responsiveness and reduced wait times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->