### PR TITLE
fix: update selectors from .thumbnail to figure

### DIFF
--- a/src/lib/components/pages/album/day/DayAlbumEditPage.svelte
+++ b/src/lib/components/pages/album/day/DayAlbumEditPage.svelte
@@ -93,7 +93,7 @@
     div {
         cursor: not-allowed;
     }
-    :global(.thumbnail:hover .notSelected) {
+    :global(figure:hover .notSelected) {
         animation: fadeIn 1400ms;
         display: inherit;
     }

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -25,8 +25,8 @@ test.describe('Smoke test', () => {
         await expect(page).toHaveTitle(/Moses|Family/i, { timeout: 15000 });
 
         // Step 2: Wait for year album thumbnails to load (AJAX)
-        // Thumbnails are in .thumbnail divs - scope to these to avoid hero images/logos
-        const yearThumb = page.locator('.thumbnail').first();
+        // Thumbnails are in <figure> elements - scope to these to avoid hero images/logos
+        const yearThumb = page.locator('figure').first();
         await expect(yearThumb).toBeVisible({ timeout: 15000 });
 
         // Verify year album thumbnail image loads
@@ -42,7 +42,7 @@ test.describe('Smoke test', () => {
         await expect(page).toHaveURL(/\/20\d{2}/, { timeout: 15000 });
 
         // Wait for day album thumbnails to load
-        const dayThumb = page.locator('.thumbnail').first();
+        const dayThumb = page.locator('figure').first();
         await expect(dayThumb).toBeVisible({ timeout: 15000 });
 
         // Verify day album thumbnail image loads
@@ -58,7 +58,7 @@ test.describe('Smoke test', () => {
         await expect(page).toHaveURL(/\/\d{2}-\d{2}/, { timeout: 15000 });
 
         // Wait for image thumbnails to load
-        const imageThumb = page.locator('.thumbnail').first();
+        const imageThumb = page.locator('figure').first();
         await expect(imageThumb).toBeVisible({ timeout: 15000 });
 
         // Verify image thumbnail loads


### PR DESCRIPTION
## Summary
- Update E2E smoke test selectors from `.thumbnail` to `figure` to match the semantic HTML change in PR #115
- Update CSS selector in DayAlbumEditPage from `:global(.thumbnail:hover .notSelected)` to `:global(figure:hover .notSelected)`

## Test plan
- [ ] E2E tests pass in CI

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated component selectors for album thumbnail elements to improve structural consistency.

* **Tests**
  * Updated test selectors to align with component structure changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->