### PR TITLE
perf: remove loading="lazy" from images

### DIFF
--- a/src/lib/components/site/Footer.svelte
+++ b/src/lib/components/site/Footer.svelte
@@ -12,7 +12,7 @@
     <picture>
         <source srcset={logoWebp} type="image/webp" />
         <source srcset={logoPng} type="image/png" />
-        <img src={logoPng} width="102" height="19" alt="" draggable="false" loading="lazy" decoding="async" />
+        <img src={logoPng} width="102" height="19" alt="" draggable="false" decoding="async" />
     </picture>
 </footer>
 

--- a/src/lib/components/site/Thumbnail.svelte
+++ b/src/lib/components/site/Thumbnail.svelte
@@ -40,7 +40,7 @@
 
 <figure>
     <a {href} aria-hidden="true" tabindex="-1"
-        >{#if src}<img {src} alt="" draggable="false" loading="lazy" decoding="async" />{:else}<div
+        >{#if src}<img {src} alt="" draggable="false" decoding="async" />{:else}<div
                 class="no-image"
             ></div>{/if}{#if creating}<div class="icon-overlay">
                 <CreateIcon width="10em" height="10em" />


### PR DESCRIPTION
## Summary
- Remove `loading="lazy"` from Thumbnail and Footer images per Lighthouse recommendation
- Lazy loading adds overhead (intersection observer, delayed fetch) that hurts performance for small images

## Test plan
- [ ] Run Lighthouse and verify the warning is gone
- [ ] Thumbnails load correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed lazy loading attribute from image elements in footer and thumbnail components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->